### PR TITLE
Adding enthusiastic confirmations

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -151,6 +151,11 @@ class RSVPConfirmCommand(RSVPEventNeededCommand):
     'no': 'yes'
   }
 
+  def match(self, input_str):
+    input_str = self.filter_for_fuck_yes_and_other_enthusiastic_confirmations(input_str)
+
+    return re.match(self.regex, input_str, flags=re.DOTALL)
+
   def confirm(self, event, sender_full_name, decision):
 
     # If they're on the opposite list, take them out.
@@ -162,6 +167,13 @@ class RSVPConfirmCommand(RSVPEventNeededCommand):
 
     return event
 
+  def filter_for_fuck_yes_and_other_enthusiastic_confirmations(self, input_str):
+    # I'm terrible using regex, this is covering, for example, "fuck yes", "yessssssss", "yeah!" and uppercases
+    # Can be expanded to more
+    if bool(re.search('yes|yeah', input_str.lower())):
+        return 'rsvp yes'
+
+    return input_str
 
   def attempt_confirm(self, event, sender_full_name, decision, limit):
     if decision == 'yes' and limit:

--- a/tests.py
+++ b/tests.py
@@ -70,6 +70,15 @@ class RSVPTest(unittest.TestCase):
 		self.assertIn('Tester', self.event['yes'])
 		self.assertNotIn('Tester', self.event['no'])
 
+	
+	def test_rsvp_FUCK_YES_with_no_prior_reservation(self):
+		output = self.issue_command('rsvp FUCK YES')
+
+		self.assertEqual(None, self.event['limit'])
+		self.assertIn('is  attending!', output['body'])
+		self.assertIn('Tester', self.event['yes'])
+		self.assertNotIn('Tester', self.event['no'])
+		
 	def test_rsvp_no_with_no_prior_reservation(self):
 		output = self.issue_command('rsvp no')
 
@@ -254,4 +263,4 @@ class RSVPTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+	unittest.main()


### PR DESCRIPTION
I overrided the match function for the RSVPConfirmCommand class to filter with filter_for_fuck_yes_and_other_enthusiastic_confirmations.

The regex in filter_for_fuck_yes_and_other_enthusiastic_confirmations can be improved, as right now is only checking for uppercases (YES, YEAH), another words before or after 'yes' (fuck yes, fuck yeah, yes yes) or characters after 'yes' (yessssssss, yes!!!!!!11!1!!1).

Can be expanded easily if needed.
