### PR TITLE
Fuzzy/enthusiastic confirm commands

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -307,7 +307,7 @@ class RSVPCreditsCommand(RSVPEventNeededCommand):
 
   def run(self, events, *args, **kwargs):
 
-    contributors = ["Mudit Ameta (SP2'15)"]
+    contributors = ["Mudit Ameta (SP2'15)", "Diego Berrocal (F2'15)", "Shad William Hopson (F1'15)", "Tom Murphy (F2'15)", "Miriam Shiffman (F2'15)", "Anjana Sofia Vakil (F2'15)"]
     testers = ["Nikki Bee (SP2'15)", "Anthony Burdi (SP1'15)", "Noella D'sa (SP2'15)", "Mudit Ameta (SP2'15)"]
 
     body = "RSVPBot was created by @**Carlos Flores (SP2'15)**\nWith **contributions** from:\n"

--- a/commands.py
+++ b/commands.py
@@ -144,7 +144,7 @@ class LimitReachedException(Exception):
   pass
 
 class RSVPConfirmCommand(RSVPEventNeededCommand):
-  regex = r'^rsvp .*\b(?P<decision>(yes|no))\b'
+  regex = r'^rsvp .*?\b(?P<decision>(yes|no))\b'
 
   opposite = {
     'yes': 'no',

--- a/commands.py
+++ b/commands.py
@@ -144,7 +144,7 @@ class LimitReachedException(Exception):
   pass
 
 class RSVPConfirmCommand(RSVPEventNeededCommand):
-  regex = r'^rsvp (?P<decision>(yes|no))$'
+  regex = r'^rsvp .*\b(?P<decision>(yes|no))\b'
 
   opposite = {
     'yes': 'no',
@@ -182,13 +182,17 @@ class RSVPConfirmCommand(RSVPEventNeededCommand):
 
     body = ERROR_INTERNAL
 
+    # TODO: 
+    # if (this.yes_no_ambigous()):
+    #   return RSVPCommandResponse("Yes no yes_no_ambigous", events)
+
     try:
       event = self.attempt_confirm(event, sender_full_name, decision, limit)
 
       # Update the events dict with the new event.
       events.update(event)
       response_string = MSG_YES_NO_CONFIRMED % (sender_full_name, '' if decision == 'yes' else '**not**')
-
+      
       return RSVPCommandResponse(response_string, events)
 
     except LimitReachedException:

--- a/feature_ideas.txt
+++ b/feature_ideas.txt
@@ -1,0 +1,8 @@
+Feature ideas
+---
+
+- Flexible yes/no commands
+
+- Private message the bot (for help)
+
+- Getting private messages (e.g. if you write a command that doesn't work like 'rsvp yes no')

--- a/feature_ideas.txt
+++ b/feature_ideas.txt
@@ -1,8 +1,0 @@
-Feature ideas
----
-
-- Flexible yes/no commands
-
-- Private message the bot (for help)
-
-- Getting private messages (e.g. if you write a command that doesn't work like 'rsvp yes no')

--- a/rsvp.py
+++ b/rsvp.py
@@ -86,7 +86,6 @@ class RSVP(object):
         commands.RSVPInitCommand(),
         commands.RSVPHelpCommand(),
         commands.RSVPCancelCommand(),
-        commands.RSVPConfirmCommand(),
         commands.RSVPSetLimitCommand(),
         commands.RSVPSetDateCommand(),
         commands.RSVPSetTimeCommand(),
@@ -95,6 +94,10 @@ class RSVP(object):
         commands.RSVPSummaryCommand(),
         commands.RSVPPingCommand(),
         commands.RSVPCreditsCommand(),
+        
+
+        # This needs to be at last for fuzzy yes|no checking
+        commands.RSVPConfirmCommand()
       )
 
       for command in command_list:

--- a/tests.py
+++ b/tests.py
@@ -286,6 +286,9 @@ class RSVPTest(unittest.TestCase):
     def test_rsvp_hell_yes(self):
         self.general_yes_with_no_prior_reservation('rsvp hell yes')
 
+    def test_rsvp_hell_yes_with_no(self):
+        self.general_yes_with_no_prior_reservation('rsvp hell to the yes I have no plans!')
+
     def test_rsvp_yes_plz(self):
         self.general_yes_with_no_prior_reservation('rsvp yes plz!')
 
@@ -293,13 +296,8 @@ class RSVPTest(unittest.TestCase):
         self.general_yes_with_no_prior_reservation('rsvp yes, after my nose job')
 
     def test_rsvp_yes_no(self):
-        output = self.issue_command('rsvp yes no')
+        self.general_yes_with_no_prior_reservation('rsvp yes no')
 
-        self.assertIn('That was confusing. RTFM.', output['body'])
-        self.assertNotIn('is  attending!', output['body'])
-        self.assertNotIn('is **not** attending!', output['body'])
-        self.assertNotIn('Tester', self.event['yes'])
-        self.assertNotIn('Tester', self.event['no'])
 
     def general_no_with_no_prior_reservation(self, msg):
         output = self.issue_command(msg)
@@ -345,6 +343,9 @@ class RSVPTest(unittest.TestCase):
         self.assertIn(self.event['description'], output['body'])
         self.assertNotIn('is  attending!', output['body'])
         self.assertNotIn('Tester', self.event['yes'])
+
+    def test_rsvp_yes_exclamation_no_plans(self):
+        self.general_yes_with_no_prior_reservation('rsvp yes! i couldn\'t say no')
 
 
 if __name__ == '__main__':

--- a/tests.py
+++ b/tests.py
@@ -265,6 +265,29 @@ class RSVPTest(unittest.TestCase):
 		self.assertIn('The description for this event has been set', output['body'])
 		self.assertIn(self.event['description'], output['body'])
 
+	def test_rsvp_ping_with_yes(self):
+		self.issue_custom_command('rsvp yes', sender_full_name='A')
+		output = self.issue_command('rsvp ping we\'re all going to the yes concert')
+		self.assertEqual(None, self.event['limit'])
+		self.assertNotIn('is  attending!', output['body'])
+		self.assertNotIn('Tester', self.event['yes'])
+		self.assertNotIn('Tester', self.event['no'])
+		self.assertIn('@**A**', output['body'])
+		self.assertIn('we\'re all going to the yes concert', output['body'])
+	
+	def general_yes_with_no_prior_reservation(self, msg):
+		output = self.issue_command(msg)
+
+		self.assertEqual(None, self.event['limit'])
+		self.assertIn('is  attending!', output['body'])
+		self.assertIn('Tester', self.event['yes'])
+		self.assertNotIn('Tester', self.event['no'])
+
+	def test_rsvp_hell_yes(self):
+		self.general_yes_with_no_prior_reservation('rsvp hell yes')
+
+	def test_rsvp_yes_plz(self):
+		self.general_yes_with_no_prior_reservation('rsvp yes plz!')
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests.py
+++ b/tests.py
@@ -5,289 +5,354 @@ import datetime
 from collections import Counter
 
 def testRSVP():
-	return rsvp.RSVP(filename='test.json')
+    return rsvp.RSVP(filename='test.json')
 
 class RSVPTest(unittest.TestCase):
 
-	def setUp(self):
-		self.rsvp = rsvp.RSVP(filename='test.json')
-		self.issue_command('rsvp init')
-		self.event = self.get_test_event()
+    def setUp(self):
+        self.rsvp = rsvp.RSVP(filename='test.json')
+        self.issue_command('rsvp init')
+        self.event = self.get_test_event()
 
-	def tearDown(self):
-		try:
-			os.remove('test.json')
-		except OSError:
-			pass
+    def tearDown(self):
+        try:
+            os.remove('test.json')
+        except OSError:
+            pass
 
-	def create_input_message(self, content='', sender_full_name='Tester', subject='Testing', display_recipient='test-stream', sender_id='12345'):
-		return {
-			'content': content,
-			'subject': subject,
-			'display_recipient': display_recipient,
-			'sender_id': sender_id,
-			'sender_full_name': sender_full_name,
-		}
+    def create_input_message(self, content='', sender_full_name='Tester', subject='Testing', display_recipient='test-stream', sender_id='12345'):
+        return {
+            'content': content,
+            'subject': subject,
+            'display_recipient': display_recipient,
+            'sender_id': sender_id,
+            'sender_full_name': sender_full_name,
+        }
 
-	def issue_command(self, command):
-		message = self.create_input_message(content=command)
-		return self.rsvp.process_message(message)
+    def issue_command(self, command):
+        message = self.create_input_message(content=command)
+        return self.rsvp.process_message(message)
 
-	def issue_custom_command(self, command, **kwargs):
-		message = self.create_input_message(content=command, **kwargs)
-		return self.rsvp.process_message(message)
-		
-	def get_test_event(self):
-		return self.rsvp.events['test-stream/Testing']
+    def issue_custom_command(self, command, **kwargs):
+        message = self.create_input_message(content=command, **kwargs)
+        return self.rsvp.process_message(message)
+        
+    def get_test_event(self):
+        return self.rsvp.events['test-stream/Testing']
 
-	def test_event_init(self):
-		self.assertIn('test-stream/Testing', self.rsvp.events)
-		self.assertEqual('12345', self.event['creator'])
+    def test_event_init(self):
+        self.assertIn('test-stream/Testing', self.rsvp.events)
+        self.assertEqual('12345', self.event['creator'])
 
-	def test_cannot_double_init(self):
-		output = self.issue_command('rsvp init')
+    def test_cannot_double_init(self):
+        output = self.issue_command('rsvp init')
 
-		self.assertIn('is already an RSVPBot event', output['body'])
+        self.assertIn('is already an RSVPBot event', output['body'])
 
-	def test_event_cancel(self):
-		output = self.issue_command('rsvp cancel')
+    def test_event_cancel(self):
+        output = self.issue_command('rsvp cancel')
 
-		self.assertNotIn('test-stream/Testing', self.rsvp.events)
-		self.assertIn('has been canceled', output['body'])
+        self.assertNotIn('test-stream/Testing', self.rsvp.events)
+        self.assertIn('has been canceled', output['body'])
 
-	def test_cannot_double_cancel(self):
-		self.issue_command('rsvp cancel')
+    def test_cannot_double_cancel(self):
+        self.issue_command('rsvp cancel')
 
-		output = self.issue_command('rsvp cancel')
-		self.assertIn('is not an RSVPBot event', output['body'])
+        output = self.issue_command('rsvp cancel')
+        self.assertIn('is not an RSVPBot event', output['body'])
 
 
-	def test_rsvp_yes_with_no_prior_reservation(self):
-		output = self.issue_command('rsvp yes')
+    def test_rsvp_yes_with_no_prior_reservation(self):
+        output = self.issue_command('rsvp yes')
 
-		self.assertEqual(None, self.event['limit'])
-		self.assertIn('is  attending!', output['body'])
-		self.assertIn('Tester', self.event['yes'])
-		self.assertNotIn('Tester', self.event['no'])
+        self.assertEqual(None, self.event['limit'])
+        self.assertIn('is  attending!', output['body'])
+        self.assertIn('Tester', self.event['yes'])
+        self.assertNotIn('Tester', self.event['no'])
 
-	def test_rsvp_no_with_no_prior_reservation(self):
-		output = self.issue_command('rsvp no')
+    def test_rsvp_no_with_no_prior_reservation(self):
+        output = self.issue_command('rsvp no')
 
-		self.assertIn('is **not** attending!', output['body'])
-		self.assertNotIn('Tester', self.event['yes'])
-		self.assertIn('Tester', self.event['no'])
+        self.assertIn('is **not** attending!', output['body'])
+        self.assertNotIn('Tester', self.event['yes'])
+        self.assertIn('Tester', self.event['no'])
 
-	def test_rsvp_yes_with_prior_reservation(self):
-		self.issue_command('rsvp yes')
-		output = self.issue_command('rsvp yes')
+    def test_rsvp_yes_with_prior_reservation(self):
+        self.issue_command('rsvp yes')
+        output = self.issue_command('rsvp yes')
 
-		count_dict = Counter(self.event['yes'])
+        count_dict = Counter(self.event['yes'])
 
-		self.assertEqual(1, count_dict['Tester'])
+        self.assertEqual(1, count_dict['Tester'])
 
-	def test_rsvp_no_with_prior_cancelation(self):
-		self.issue_command('rsvp no')
-		output = self.issue_command('rsvp no')
+    def test_rsvp_no_with_prior_cancelation(self):
+        self.issue_command('rsvp no')
+        output = self.issue_command('rsvp no')
 
-		count_dict = Counter(self.event['no'])
+        count_dict = Counter(self.event['no'])
 
-		self.assertEqual(1, count_dict['Tester'])
+        self.assertEqual(1, count_dict['Tester'])
 
-	def test_set_limit(self):
-		output = self.issue_command('rsvp set limit 1')
+    def test_set_limit(self):
+        output = self.issue_command('rsvp set limit 1')
 
-		self.assertIn('has been set to **1**', output['body'])
-		self.assertEqual(1, self.event['limit'])
+        self.assertIn('has been set to **1**', output['body'])
+        self.assertEqual(1, self.event['limit'])
 
-	def test_cannot_rsvp_on_a_full_event(self):
-		self.issue_command('rsvp set limit 1')
-		self.issue_command('rsvp yes')
-		output = self.issue_custom_command('rsvp yes', sender_full_name='Tester 2')
+    def test_cannot_rsvp_on_a_full_event(self):
+        self.issue_command('rsvp set limit 1')
+        self.issue_command('rsvp yes')
+        output = self.issue_custom_command('rsvp yes', sender_full_name='Tester 2')
 
-		self.assertIn('The **limit** for this event has been reached!', output['body'])
+        self.assertIn('The **limit** for this event has been reached!', output['body'])
 
-	def test_set_date(self):
-		output = self.issue_command('rsvp set date 02/25/2100')
+    def test_set_date(self):
+        output = self.issue_command('rsvp set date 02/25/2100')
 
-		self.assertIn(
-			'The date for this event has been set to **02/25/2100**!',
-			output['body']
-		)
+        self.assertIn(
+            'The date for this event has been set to **02/25/2100**!',
+            output['body']
+        )
 
-		self.assertEqual(
-			'2100-02-25',
-			self.event['date']
-		)
-
-	def test_set_date(self):
-		output = self.issue_command('rsvp set date 02/25/1000')
+        self.assertEqual(
+            '2100-02-25',
+            self.event['date']
+        )
+
+    def test_set_date(self):
+        output = self.issue_command('rsvp set date 02/25/1000')
 
-		self.assertIn(
-			'Oops! **02/25/1000** is not a valid date in the **future**!',
-			output['body']
-		)
-
-		self.assertNotEqual(
-			'1000-02-25',
-			self.event['date']
-		)
-
-
-
-	def test_set_time(self):
-		output = self.issue_command('rsvp set time 10:30')
-
-		self.assertIn('has been set to **10:30**', output['body'])
-		self.assertEqual('10:30', self.event['time'])
-
-	def test_set_time_fail(self):
-		self.issue_command('rsvp init')
-
-		output = self.issue_command('rsvp set time 99:99')
-
-		self.assertIn('is not a valid time', output['body'])
-		self.assertNotEqual('99:99', self.event['time'])
-
-
-	def test_new_event_is_today(self):
-		today = str(datetime.date.today())
-		self.assertEqual(today, self.event['date'])
-
-	def test_new_event_is_all_day(self):
-		self.assertEqual(self.event['time'], None)
-
-	def test_set_event_all_day(self):
-		self.issue_command('rsvp set time 10:30')
-		output = self.issue_command('rsvp set time allday')
-		self.assertEqual(self.event['time'], None)
-		self.assertIn('all day long event.', output['body'])
+        self.assertIn(
+            'Oops! **02/25/1000** is not a valid date in the **future**!',
+            output['body']
+        )
+
+        self.assertNotEqual(
+            '1000-02-25',
+            self.event['date']
+        )
+
+
+
+    def test_set_time(self):
+        output = self.issue_command('rsvp set time 10:30')
+
+        self.assertIn('has been set to **10:30**', output['body'])
+        self.assertEqual('10:30', self.event['time'])
+
+    def test_set_time_fail(self):
+        self.issue_command('rsvp init')
+
+        output = self.issue_command('rsvp set time 99:99')
+
+        self.assertIn('is not a valid time', output['body'])
+        self.assertNotEqual('99:99', self.event['time'])
+
+
+    def test_new_event_is_today(self):
+        today = str(datetime.date.today())
+        self.assertEqual(today, self.event['date'])
+
+    def test_new_event_is_all_day(self):
+        self.assertEqual(self.event['time'], None)
+
+    def test_set_event_all_day(self):
+        self.issue_command('rsvp set time 10:30')
+        output = self.issue_command('rsvp set time allday')
+        self.assertEqual(self.event['time'], None)
+        self.assertIn('all day long event.', output['body'])
 
-	def test_set_description(self):
-		output = self.issue_command('rsvp set description This is the description of the event!')
-		self.assertEqual(self.event['description'], 'This is the description of the event!')
-		self.assertIn('The description for this event has been set', output['body'])
-		self.assertIn(self.event['description'], output['body'])
-
-	def test_set_place(self):
-		output = self.issue_command('rsvp set place Hopper!')
-		self.assertEqual(self.event['place'], 'Hopper!')
-		self.assertIn('The place for this event has been set', output['body'])
-		self.assertIn(self.event['place'], output['body'])
-
-	def test_summary_shows_NA_for_place_not_set(self):
-		output = self.issue_command('rsvp summary')
-		self.assertIn('**Where**|N/A', output['body'])
-
-	def test_summary_whos_NA_for_description_not_set(self):
-		output = self.issue_command('rsvp summary')
-		self.assertIn('**What**|N/A', output['body'])
-
-	def test_summary_shows_allday_for_allday_event(self):
-		output = self.issue_command('rsvp summary')
-		self.assertIn('(All day)', output['body'])
-
-	def test_summary_shows_description(self):
-		self.issue_command('rsvp set description test description')
-		output = self.issue_command('rsvp summary')
-		self.assertIn('**What**|test description', output['body'])
-
-	def test_summary_shows_place(self):
-		self.issue_command('rsvp set place Hopper!')
-		output = self.issue_command('rsvp summary')
-		self.assertIn('**Where**|Hopper!', output['body'])
-
-	def test_summary_shows_date(self):
-		self.issue_command('rsvp set date 02/25/2100')
-		output = self.issue_command('rsvp summary')
-		self.assertIn('**When**|2100-02-25', output['body'])
-
-	def test_summary_shows_limit(self):
-		self.issue_command('rsvp set limit 1')
-		output = self.issue_command('rsvp summary')
-		self.assertIn('**Limit**|1/1', output['body'])
-
-	def test_summary_shows_no_limit_on_limit_not_set(self):
-		output = self.issue_command('rsvp summary')
-		self.assertIn('**Limit**|No Limit!', output['body'])
-
-	def test_summary_shows_time(self):
-		self.issue_command('rsvp set time 10:30')
-		output = self.issue_command('rsvp summary')
-		self.assertIn('10:30', output['body'])
-
-	def test_summary_shows_thread_name(self):
-		output = self.issue_command('rsvp summary')
-		self.assertIn('Testing', output['body'])
-
-	def test_limit_actually_works(self):
-		self.issue_command('rsvp set limit 500')
-		self.issue_command('rsvp yes')
-		output = self.issue_custom_command('rsvp yes', sender_full_name='Sender B')
-
-		self.assertEqual('@**Sender B** is  attending!', output['body'])
-		self.assertIn('Sender B', self.event['yes'])
-		self.assertEqual(498, self.event['limit'] - len(self.event['yes']))
-
-	def test_ping_yes(self):
-		self.issue_custom_command('rsvp yes', sender_full_name='A')
-		self.issue_custom_command('rsvp yes', sender_full_name='B')
-		self.issue_custom_command('rsvp yes', sender_full_name='C')
-		self.issue_custom_command('rsvp yes', sender_full_name='D')
-
-		self.issue_custom_command('rsvp no', sender_full_name='E')
-		self.issue_custom_command('rsvp no', sender_full_name='F')
-		self.issue_custom_command('rsvp no', sender_full_name='G')
-		self.issue_custom_command('rsvp no', sender_full_name='H')
-
-		output = self.issue_command('rsvp ping')
-
-		self.assertIn('@**A**', output['body'])
-		self.assertIn('@**B**', output['body'])
-		self.assertIn('@**C**', output['body'])
-		self.assertIn('@**D**', output['body'])
-
-		self.assertNotIn('@**E**', output['body'])
-		self.assertNotIn('@**F**', output['body'])
-		self.assertNotIn('@**G**', output['body'])
-		self.assertNotIn('@**H**', output['body'])
-
-	def test_ping_message(self):
-		self.issue_custom_command('rsvp yes', sender_full_name='A')
-
-		output = self.issue_command('rsvp ping message!!!')
-
-		self.assertIn('@**A**', output['body'])
-		self.assertIn('message!!!', output['body'])
-
-	def test_add_description_with_message_including_yeah(self):
-		output = self.issue_command('rsvp set description This is the description of the event! yeah!')
-		self.assertEqual(self.event['description'], 'This is the description of the event! yeah!')
-		self.assertIn('The description for this event has been set', output['body'])
-		self.assertIn(self.event['description'], output['body'])
-
-	def test_rsvp_ping_with_yes(self):
-		self.issue_custom_command('rsvp yes', sender_full_name='A')
-		output = self.issue_command('rsvp ping we\'re all going to the yes concert')
-		self.assertEqual(None, self.event['limit'])
-		self.assertNotIn('is  attending!', output['body'])
-		self.assertNotIn('Tester', self.event['yes'])
-		self.assertNotIn('Tester', self.event['no'])
-		self.assertIn('@**A**', output['body'])
-		self.assertIn('we\'re all going to the yes concert', output['body'])
-	
-	def general_yes_with_no_prior_reservation(self, msg):
-		output = self.issue_command(msg)
-
-		self.assertEqual(None, self.event['limit'])
-		self.assertIn('is  attending!', output['body'])
-		self.assertIn('Tester', self.event['yes'])
-		self.assertNotIn('Tester', self.event['no'])
-
-	def test_rsvp_hell_yes(self):
-		self.general_yes_with_no_prior_reservation('rsvp hell yes')
-
-	def test_rsvp_yes_plz(self):
-		self.general_yes_with_no_prior_reservation('rsvp yes plz!')
+    def test_set_description(self):
+        output = self.issue_command('rsvp set description This is the description of the event!')
+        self.assertEqual(self.event['description'], 'This is the description of the event!')
+        self.assertIn('The description for this event has been set', output['body'])
+        self.assertIn(self.event['description'], output['body'])
+
+    def test_set_place(self):
+        output = self.issue_command('rsvp set place Hopper!')
+        self.assertEqual(self.event['place'], 'Hopper!')
+        self.assertIn('The place for this event has been set', output['body'])
+        self.assertIn(self.event['place'], output['body'])
+
+    def test_summary_shows_NA_for_place_not_set(self):
+        output = self.issue_command('rsvp summary')
+        self.assertIn('**Where**|N/A', output['body'])
+
+    def test_summary_whos_NA_for_description_not_set(self):
+        output = self.issue_command('rsvp summary')
+        self.assertIn('**What**|N/A', output['body'])
+
+    def test_summary_shows_allday_for_allday_event(self):
+        output = self.issue_command('rsvp summary')
+        self.assertIn('(All day)', output['body'])
+
+    def test_summary_shows_description(self):
+        self.issue_command('rsvp set description test description')
+        output = self.issue_command('rsvp summary')
+        self.assertIn('**What**|test description', output['body'])
+
+    def test_summary_shows_place(self):
+        self.issue_command('rsvp set place Hopper!')
+        output = self.issue_command('rsvp summary')
+        self.assertIn('**Where**|Hopper!', output['body'])
+
+    def test_summary_shows_date(self):
+        self.issue_command('rsvp set date 02/25/2100')
+        output = self.issue_command('rsvp summary')
+        self.assertIn('**When**|2100-02-25', output['body'])
+
+    def test_summary_shows_limit(self):
+        self.issue_command('rsvp set limit 1')
+        output = self.issue_command('rsvp summary')
+        self.assertIn('**Limit**|1/1', output['body'])
+
+    def test_summary_shows_no_limit_on_limit_not_set(self):
+        output = self.issue_command('rsvp summary')
+        self.assertIn('**Limit**|No Limit!', output['body'])
+
+    def test_summary_shows_time(self):
+        self.issue_command('rsvp set time 10:30')
+        output = self.issue_command('rsvp summary')
+        self.assertIn('10:30', output['body'])
+
+    def test_summary_shows_thread_name(self):
+        output = self.issue_command('rsvp summary')
+        self.assertIn('Testing', output['body'])
+
+    def test_limit_actually_works(self):
+        self.issue_command('rsvp set limit 500')
+        self.issue_command('rsvp yes')
+        output = self.issue_custom_command('rsvp yes', sender_full_name='Sender B')
+
+        self.assertEqual('@**Sender B** is  attending!', output['body'])
+        self.assertIn('Sender B', self.event['yes'])
+        self.assertEqual(498, self.event['limit'] - len(self.event['yes']))
+
+    def test_ping_yes(self):
+        self.issue_custom_command('rsvp yes', sender_full_name='A')
+        self.issue_custom_command('rsvp yes', sender_full_name='B')
+        self.issue_custom_command('rsvp yes', sender_full_name='C')
+        self.issue_custom_command('rsvp yes', sender_full_name='D')
+
+        self.issue_custom_command('rsvp no', sender_full_name='E')
+        self.issue_custom_command('rsvp no', sender_full_name='F')
+        self.issue_custom_command('rsvp no', sender_full_name='G')
+        self.issue_custom_command('rsvp no', sender_full_name='H')
+
+        output = self.issue_command('rsvp ping')
+
+        self.assertIn('@**A**', output['body'])
+        self.assertIn('@**B**', output['body'])
+        self.assertIn('@**C**', output['body'])
+        self.assertIn('@**D**', output['body'])
+
+        self.assertNotIn('@**E**', output['body'])
+        self.assertNotIn('@**F**', output['body'])
+        self.assertNotIn('@**G**', output['body'])
+        self.assertNotIn('@**H**', output['body'])
+
+    def test_ping_message(self):
+        self.issue_custom_command('rsvp yes', sender_full_name='A')
+
+        output = self.issue_command('rsvp ping message!!!')
+
+        self.assertIn('@**A**', output['body'])
+        self.assertIn('message!!!', output['body'])
+
+    def test_add_description_with_message_including_yeah(self):
+        output = self.issue_command('rsvp set description This is the description of the event! yeah!')
+        self.assertEqual(self.event['description'], 'This is the description of the event! yeah!')
+        self.assertIn('The description for this event has been set', output['body'])
+        self.assertIn(self.event['description'], output['body'])
+
+    def test_rsvp_ping_with_yes(self):
+        self.issue_custom_command('rsvp yes', sender_full_name='A')
+        output = self.issue_command('rsvp ping we\'re all going to the yes concert')
+        self.assertEqual(None, self.event['limit'])
+        self.assertNotIn('is  attending!', output['body'])
+        self.assertNotIn('Tester', self.event['yes'])
+        self.assertNotIn('Tester', self.event['no'])
+        self.assertIn('@**A**', output['body'])
+        self.assertIn('we\'re all going to the yes concert', output['body'])
+    
+    def general_yes_with_no_prior_reservation(self, msg):
+        output = self.issue_command(msg)
+
+        self.assertEqual(None, self.event['limit'])
+        self.assertIn('is  attending!', output['body'])
+        self.assertIn('Tester', self.event['yes'])
+        self.assertNotIn('Tester', self.event['no'])
+
+    def test_rsvp_hell_yes(self):
+        self.general_yes_with_no_prior_reservation('rsvp hell yes')
+
+    def test_rsvp_yes_plz(self):
+        self.general_yes_with_no_prior_reservation('rsvp yes plz!')
+
+    def test_rsvp_yes_with_nose_in_it(self):
+        self.general_yes_with_no_prior_reservation('rsvp yes, after my nose job')
+
+    def test_rsvp_yes_no(self):
+        output = self.issue_command('rsvp yes no')
+
+        self.assertIn('That was confusing. RTFM.', output['body'])
+        self.assertNotIn('is  attending!', output['body'])
+        self.assertNotIn('is **not** attending!', output['body'])
+        self.assertNotIn('Tester', self.event['yes'])
+        self.assertNotIn('Tester', self.event['no'])
+
+    def general_no_with_no_prior_reservation(self, msg):
+        output = self.issue_command(msg)
+
+        self.assertEqual(None, self.event['limit'])
+        self.assertNotIn('is  attending!', output['body'])
+        self.assertIn('is **not** attending!', output['body'])
+        self.assertNotIn('Tester', self.event['yes'])
+        self.assertIn('Tester', self.event['no'])
+
+    def test_rsvp_hell_no(self):
+        self.general_no_with_no_prior_reservation('rsvp hell no!')
+
+    def test_rsvp_no_way(self):
+        self.general_no_with_no_prior_reservation('rsvp no, i\'m busy')
+
+    def rsvp_word_contains_command(self, msg):
+        output = self.issue_command(msg)
+        self.assertEqual(None, self.event['limit'])
+        self.assertIn('is not a valid RSVPBot command!', output['body'])
+        self.assertNotIn('is  attending!', output['body'])
+        self.assertNotIn('is **not** attending!', output['body'])
+        self.assertNotIn('Tester', self.event['yes'])
+        self.assertNotIn('Tester', self.event['no'])
+
+    def test_rsvp_nose(self):
+        self.rsvp_word_contains_command('rsvp nose jobs')
+
+
+    def test_rsvp_yesterday(self):
+        self.rsvp_word_contains_command('rsvp yesterday')
+    
+    def test_rsvp_eyes(self):
+        self.rsvp_word_contains_command('rsvp eyes')
+
+    def test_rsvp_no_eyes(self):
+        self.general_no_with_no_prior_reservation('rsvp no eyes')
+
+    def test_rsvp_description_containing_yes(self):
+        output = self.issue_command('rsvp set description lets do this yes!')
+        self.assertEqual(self.event['description'], 'lets do this yes!')
+        self.assertIn('The description for this event has been set', output['body'])
+        self.assertIn(self.event['description'], output['body'])
+        self.assertNotIn('is  attending!', output['body'])
+        self.assertNotIn('Tester', self.event['yes'])
+
 
 if __name__ == '__main__':
     unittest.main()
+
+
+
+
+
+
+


### PR DESCRIPTION
Allows RSVPbot to accept confirm commands such as `rsvp yes!!!!`,  `rsvp hellz yes`, or `rsvp no way jose`.

If the reply contains both `yes` and `no`, the leftmost one will be accepted as the command. For example, `rsvp yes I have no plans` will add the sender to the `yes` list, but `rsvp no way I would miss it yes` will add the sender to the `no` list.

Does NOT accept e.g. `rsvp yeah`, `rsvp noooooo`.

The new tests added to `tests.py` demonstrate other intended behavior. 

(Jointly created by the `zulip > improving rsvpbot` dojo members: Diego Berrocal (F2'15), Shad William Hopson (F1'15), Tom Murphy (F2'15), Miriam Shiffman (F2'15), and Anjana Sofia Vakil (F2'15))
