### PR TITLE
Add private message capability to RSVPbot

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -63,13 +63,17 @@ class bot():
             self.send_message(message)
             
     def send_message(self, msg):
-        ''' Sends a message to zulip stream
+        ''' Sends a message to zulip stream or user
         '''
 
+        msg_to = msg['display_recipient']
+        if msg['type'] == 'private':
+            msg_to = msg['sender_email']
+
         self.client.send_message({
-            "type": "stream",
+            "type": msg['type'],
             "subject": msg["subject"],
-            "to": msg['display_recipient'],
+            "to": msg_to,
             "content": msg['body']
         })
 

--- a/commands.py
+++ b/commands.py
@@ -30,9 +30,10 @@ of this class.
 
 """
 class RSVPCommandResponse(object):
-  def __init__(self, body, events):
+  def __init__(self, body, events, message_type):
     self.body = body
     self.events = events
+    self.message_type = message_type
 
 
 """
@@ -62,7 +63,7 @@ class RSVPEventNeededCommand(RSVPCommand):
     event = kwargs.get('event')
     if event:
       return self.run(events, *args, **kwargs)
-    return RSVPCommandResponse(ERROR_NOT_AN_EVENT, events)
+    return RSVPCommandResponse(ERROR_NOT_AN_EVENT, events, 'stream')
 
 
 class RSVPInitCommand(RSVPCommand):
@@ -96,7 +97,7 @@ class RSVPInitCommand(RSVPCommand):
         }
       )
 
-    return RSVPCommandResponse(body, events)
+    return RSVPCommandResponse(body, events, 'stream')
 
 class RSVPHelpCommand(RSVPCommand):
   regex = r'^rsvp help$'
@@ -118,7 +119,7 @@ class RSVPHelpCommand(RSVPCommand):
     body += "`rsvp summary`|Displays a summary of this event, including the description, and list of attendees.\n"
     body += "`rsvp credits`|Lists all the awesome people that made RSVPBot a reality.\n"
 
-    return RSVPCommandResponse(body, events)
+    return RSVPCommandResponse(body, events, 'stream')
 
 
 class RSVPCancelCommand(RSVPEventNeededCommand):
@@ -139,7 +140,7 @@ class RSVPCancelCommand(RSVPEventNeededCommand):
     else:
       body = ERROR_NOT_AUTHORIZED_TO_DELETE
 
-    return RSVPCommandResponse(body, events)
+    return RSVPCommandResponse(body, events, 'stream')
 
 class LimitReachedException(Exception):
   pass
@@ -225,10 +226,10 @@ class RSVPConfirmCommand(RSVPEventNeededCommand):
       events.update(event)
       response_string = MSG_YES_NO_CONFIRMED % (sender_full_name, '' if decision == 'yes' else '**not**')
       response_string = vip_prefix + response_string + vip_postfix
-      return RSVPCommandResponse(response_string, events)
+      return RSVPCommandResponse(response_string, events, 'stream')
 
     except LimitReachedException:
-      return RSVPCommandResponse(ERROR_LIMIT_REACHED, events)
+      return RSVPCommandResponse(ERROR_LIMIT_REACHED, events, 'stream')
 
 
 
@@ -240,7 +241,7 @@ class RSVPSetLimitCommand(RSVPEventNeededCommand):
     event = kwargs.pop('event')
     attendance_limit = int(kwargs.pop('limit'))
     event['limit'] = attendance_limit
-    return RSVPCommandResponse(MSG_ATTENDANCE_LIMIT_SET % (attendance_limit), events)
+    return RSVPCommandResponse(MSG_ATTENDANCE_LIMIT_SET % (attendance_limit), events, 'stream')
 
 
 class RSVPSetDateCommand(RSVPEventNeededCommand):
@@ -272,7 +273,7 @@ class RSVPSetDateCommand(RSVPEventNeededCommand):
     else:
       body = ERROR_DATE_NOT_VALID % (month, day, year)
 
-    return RSVPCommandResponse(body, events)
+    return RSVPCommandResponse(body, events, 'stream')
 
 
 class RSVPSetTimeCommand(RSVPEventNeededCommand):
@@ -291,7 +292,7 @@ class RSVPSetTimeCommand(RSVPEventNeededCommand):
     else:
       body = ERROR_TIME_NOT_VALID % (hours, minutes)
       
-    return RSVPCommandResponse(body, events)
+    return RSVPCommandResponse(body, events, 'stream')
 
 class RSVPSetTimeAllDayCommand(RSVPEventNeededCommand):
   regex = r'^rsvp set time allday$'
@@ -299,7 +300,7 @@ class RSVPSetTimeAllDayCommand(RSVPEventNeededCommand):
   def run(self, events, *args, **kwargs):
     event_id = kwargs.pop('event_id')
     events[event_id]['time'] = None
-    return RSVPCommandResponse(MSG_TIME_SET_ALLDAY, events)
+    return RSVPCommandResponse(MSG_TIME_SET_ALLDAY, events, 'stream')
 
 class RSVPSetStringAttributeCommand(RSVPEventNeededCommand):
   regex = r'^rsvp set (?P<attribute>(place|description)) (?P<value>.+)$'
@@ -312,7 +313,7 @@ class RSVPSetStringAttributeCommand(RSVPEventNeededCommand):
     events[event_id][attribute] = value
 
     body = MSG_STRING_ATTR_SET % (attribute, value)
-    return RSVPCommandResponse(body, events)
+    return RSVPCommandResponse(body, events, 'stream')
 
 
 class RSVPPingCommand(RSVPEventNeededCommand):
@@ -330,7 +331,7 @@ class RSVPPingCommand(RSVPEventNeededCommand):
     if message:
       body += ('\n' + message)
 
-    return RSVPCommandResponse(body, events)
+    return RSVPCommandResponse(body, events, 'stream')
 
 
 
@@ -351,7 +352,7 @@ class RSVPCreditsCommand(RSVPEventNeededCommand):
 
     body += "\nThe code for **RSVPBot** is available at https://github.com/kokeshii/RSVPBot"
 
-    return RSVPCommandResponse(body, events)
+    return RSVPCommandResponse(body, events, 'stream')
 
 class RSVPSummaryCommand(RSVPEventNeededCommand):
   regex = r'^rsvp summary$'
@@ -389,5 +390,5 @@ class RSVPSummaryCommand(RSVPEventNeededCommand):
       confirmation_table += '\t|\t'
 
     body = summary_table + '\n\n' + confirmation_table
-    return RSVPCommandResponse(body, events)
+    return RSVPCommandResponse(body, events, 'stream')
 

--- a/rsvp.py
+++ b/rsvp.py
@@ -65,7 +65,9 @@ class RSVP(object):
     """
     Processes the received message and returns a new message, to send back to the user.
     """
-    body = self.route(message)
+    body, message_type = self.route(message)
+    if message['type'] != 'private':
+        message['type'] = message_type
     return self.create_message_from_message(message, body)
 
   def route(self, message):
@@ -118,9 +120,9 @@ class RSVP(object):
 
           self.events = response.events
           self.commit_events()
-          return response.body
+          return response.body, response.message_type
 
-      return ERROR_INVALID_COMMAND % (content)
+      return ERROR_INVALID_COMMAND % (content), 'private'
 
 
   def create_message_from_message(self, message, body):
@@ -131,6 +133,8 @@ class RSVP(object):
       return {
         'subject': message['subject'],
         'display_recipient': message['display_recipient'],
+        'sender_email': message['sender_email'],
+        'type': message['type'],
         'body': body
       }
  

--- a/rsvp.py
+++ b/rsvp.py
@@ -122,7 +122,8 @@ class RSVP(object):
           self.commit_events()
           return response.body, response.message_type
 
-      return ERROR_INVALID_COMMAND % (content), 'private'
+      return ERROR_INVALID_COMMAND % (content), 'stream'
+    return None, 'private'
 
 
   def create_message_from_message(self, message, body):

--- a/tests.py
+++ b/tests.py
@@ -20,13 +20,15 @@ class RSVPTest(unittest.TestCase):
         except OSError:
             pass
 
-    def create_input_message(self, content='', sender_full_name='Tester', subject='Testing', display_recipient='test-stream', sender_id='12345'):
+    def create_input_message(self, content='', sender_full_name='Tester', subject='Testing', display_recipient='test-stream', sender_id='12345', message_type='stream', sender_email='a@example.com'):
         return {
             'content': content,
             'subject': subject,
             'display_recipient': display_recipient,
             'sender_id': sender_id,
             'sender_full_name': sender_full_name,
+            'sender_email': sender_email,
+            'type': message_type,
         }
 
     def issue_command(self, command):
@@ -347,6 +349,15 @@ class RSVPTest(unittest.TestCase):
     def test_rsvp_yes_exclamation_no_plans(self):
         self.general_yes_with_no_prior_reservation('rsvp yes! i couldn\'t say no')
 
+    def test_rsvp_private_message(self):
+        output = self.issue_custom_command('rsvp yes', message_type='private')
+        self.assertEqual('private', output['type'])
+        self.assertEqual('a@example.com', output['sender_email'])
+
+    def test_rsvp_stream_message(self):
+        output = self.issue_custom_command('rsvp yes', message_type='stream')
+        self.assertEqual('stream', output['type'])
+        self.assertEqual('test-stream', output['display_recipient'])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
[EDIT] This has now been tested in production zulip
~~NOTE: this hasn't been tested in production zulip yet~~

Private message capability is currently off for all commands, except
when no command is found. It can be added to any command by changing the
return line of the RSVPCommandResponse.

e.g.
from: return RSVPCommandResponse(body, events, 'stream')
to: return RSVPCommandResponse(body, events, 'private')
