### PR TITLE
Refactor key_word to be set once, used everywhere

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -21,7 +21,7 @@ class bot():
         self.subscribed_streams = subscribed_streams
         self.client = zulip.Client(zulip_username, zulip_api_key, site=zulip_site)
         self.subscriptions = self.subscribe_to_streams()
-        self.rsvp = rsvp.RSVP()
+        self.rsvp = rsvp.RSVP(key_word)
 
 
     @property

--- a/commands.py
+++ b/commands.py
@@ -41,8 +41,10 @@ Base class for an RSVPCommand
 class RSVPCommand(object):
   regex = None
 
-  def __init__(self, *args, **kwargs):
-    pass
+  def __init__(self, prefix, *args, **kwargs):
+    # prefix is the command start the bot listens to, typically 'rsvp'
+    self.prefix = r'^' + prefix + r' '
+    self.regex = self.prefix + self.regex
 
   def match(self, input_str):
     return re.match(self.regex, input_str, flags=re.DOTALL)
@@ -66,7 +68,7 @@ class RSVPEventNeededCommand(RSVPCommand):
 
 
 class RSVPInitCommand(RSVPCommand):
-  regex = r'^rsvp init$'
+  regex = r'init$'
 
   def run(self, events, *args, **kwargs):
     sender_id   = kwargs.pop('sender_id')
@@ -99,7 +101,7 @@ class RSVPInitCommand(RSVPCommand):
     return RSVPCommandResponse(body, events)
 
 class RSVPHelpCommand(RSVPCommand):
-  regex = r'^rsvp help$'
+  regex = r'help$'
 
   def run(self, events, *args, **kwargs):
     body = "**Command**|**Description**\n"
@@ -122,7 +124,7 @@ class RSVPHelpCommand(RSVPCommand):
 
 
 class RSVPCancelCommand(RSVPEventNeededCommand):
-  regex = r'^rsvp cancel$'
+  regex = r'cancel$'
 
   def run(self, events, *args, **kwargs):
     event_id = kwargs.pop('event_id')
@@ -145,7 +147,7 @@ class LimitReachedException(Exception):
   pass
 
 class RSVPConfirmCommand(RSVPEventNeededCommand):
-  regex = r'^rsvp .*?\b(?P<decision>(yes|no))\b'
+  regex = r'.*?\b(?P<decision>(yes|no))\b'
 
   opposite = {
     'yes': 'no',
@@ -233,7 +235,7 @@ class RSVPConfirmCommand(RSVPEventNeededCommand):
 
 
 class RSVPSetLimitCommand(RSVPEventNeededCommand):
-  regex = r'^rsvp set limit (?P<limit>\d+)$'
+  regex = r'set limit (?P<limit>\d+)$'
 
   def run(self, events, *args, **kwargs):
 
@@ -244,7 +246,7 @@ class RSVPSetLimitCommand(RSVPEventNeededCommand):
 
 
 class RSVPSetDateCommand(RSVPEventNeededCommand):
-  regex = r'^rsvp set date (?P<month>\d{1,2})/(?P<day>\d{1,2})/(?P<year>\d{4})$'
+  regex = r'set date (?P<month>\d{1,2})/(?P<day>\d{1,2})/(?P<year>\d{4})$'
 
   def validate_future_date(self, day, month, year):
     today = datetime.date.today()
@@ -276,7 +278,7 @@ class RSVPSetDateCommand(RSVPEventNeededCommand):
 
 
 class RSVPSetTimeCommand(RSVPEventNeededCommand):
-  regex = r'^rsvp set time (?P<hours>\d{1,2})\:(?P<minutes>\d{1,2})$'
+  regex = r'set time (?P<hours>\d{1,2})\:(?P<minutes>\d{1,2})$'
 
   def run(self, events, *args, **kwargs):
     event_id = kwargs.pop('event_id')
@@ -294,7 +296,7 @@ class RSVPSetTimeCommand(RSVPEventNeededCommand):
     return RSVPCommandResponse(body, events)
 
 class RSVPSetTimeAllDayCommand(RSVPEventNeededCommand):
-  regex = r'^rsvp set time allday$'
+  regex = r'set time allday$'
 
   def run(self, events, *args, **kwargs):
     event_id = kwargs.pop('event_id')
@@ -302,7 +304,7 @@ class RSVPSetTimeAllDayCommand(RSVPEventNeededCommand):
     return RSVPCommandResponse(MSG_TIME_SET_ALLDAY, events)
 
 class RSVPSetStringAttributeCommand(RSVPEventNeededCommand):
-  regex = r'^rsvp set (?P<attribute>(place|description)) (?P<value>.+)$'
+  regex = r'set (?P<attribute>(place|description)) (?P<value>.+)$'
 
   def run(self, events, *args, **kwargs):
     event_id = kwargs.pop('event_id')
@@ -316,7 +318,10 @@ class RSVPSetStringAttributeCommand(RSVPEventNeededCommand):
 
 
 class RSVPPingCommand(RSVPEventNeededCommand):
-  regex = r'^(rsvp ping)$|(rsvp ping (?P<message>.+))$'
+  regex = r'^({key_word} ping)$|({key_word} ping (?P<message>.+))$'
+
+  def __init__(self, prefix, *args, **kwargs):
+    self.regex = self.regex.format(key_word=prefix)
 
   def run(self, events, *args, **kwargs):
     event = kwargs.pop('event')
@@ -335,7 +340,7 @@ class RSVPPingCommand(RSVPEventNeededCommand):
 
 
 class RSVPCreditsCommand(RSVPEventNeededCommand):
-  regex = r'^rsvp credits$'
+  regex = r'credits$'
 
   def run(self, events, *args, **kwargs):
 
@@ -354,7 +359,7 @@ class RSVPCreditsCommand(RSVPEventNeededCommand):
     return RSVPCommandResponse(body, events)
 
 class RSVPSummaryCommand(RSVPEventNeededCommand):
-  regex = r'^rsvp summary$'
+  regex = r'summary$'
 
   def run(self, events, *args, **kwargs):
     event = kwargs.pop('event')

--- a/rsvp.py
+++ b/rsvp.py
@@ -25,12 +25,29 @@ MSG_YES_NO_CONFIRMED           = u'@**%s** is %s attending!'
 
 class RSVP(object):
 
-  def __init__(self, filename='events.json'):
+  def __init__(self, key_word, filename='events.json'):
     """
     When created, this instance will try to open self.filename. It will always
     keep a copy in memory of the whole events dictionary and commit it when necessary.
     """
+    self.key_word = key_word
     self.filename = filename
+    self.command_list = (
+      commands.RSVPInitCommand(key_word),
+      commands.RSVPHelpCommand(key_word),
+      commands.RSVPCancelCommand(key_word),
+      commands.RSVPSetLimitCommand(key_word),
+      commands.RSVPSetDateCommand(key_word),
+      commands.RSVPSetTimeCommand(key_word),
+      commands.RSVPSetTimeAllDayCommand(key_word),
+      commands.RSVPSetStringAttributeCommand(key_word),
+      commands.RSVPSummaryCommand(key_word),
+      commands.RSVPPingCommand(key_word),
+      commands.RSVPCreditsCommand(key_word),
+
+      # This needs to be at last for fuzzy yes|no checking
+      commands.RSVPConfirmCommand(key_word)
+    )
 
     try:
       with open(self.filename, "r") as f:
@@ -81,26 +98,8 @@ class RSVP(object):
 
     event_id = self.event_id(message)
 
-    if content.startswith('rsvp'):
-      command_list = (
-        commands.RSVPInitCommand(),
-        commands.RSVPHelpCommand(),
-        commands.RSVPCancelCommand(),
-        commands.RSVPSetLimitCommand(),
-        commands.RSVPSetDateCommand(),
-        commands.RSVPSetTimeCommand(),
-        commands.RSVPSetTimeAllDayCommand(),
-        commands.RSVPSetStringAttributeCommand(),
-        commands.RSVPSummaryCommand(),
-        commands.RSVPPingCommand(),
-        commands.RSVPCreditsCommand(),
-        
-
-        # This needs to be at last for fuzzy yes|no checking
-        commands.RSVPConfirmCommand()
-      )
-
-      for command in command_list:
+    if content.startswith(self.key_word):
+      for command in self.command_list:
         matches = command.match(content)
         if matches:
           kwargs = {

--- a/tests.py
+++ b/tests.py
@@ -10,7 +10,7 @@ def testRSVP():
 class RSVPTest(unittest.TestCase):
 
     def setUp(self):
-        self.rsvp = rsvp.RSVP(filename='test.json')
+        self.rsvp = rsvp.RSVP('rsvp', filename='test.json')
         self.issue_command('rsvp init')
         self.event = self.get_test_event()
 


### PR DESCRIPTION
The bot will now use it's key_word as it's regex prefix for matching bot
commands. So the bot's listening string is now set in only one location
and then used everywhere.

This will help with testing. One can just set the key_word to a new string, and all the messages the bot listens to and the regex matches will all use it.
