### PR TITLE
RSVP YES!!!!

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -47,7 +47,7 @@ class RSVPCommand(object):
     self.regex = self.prefix + self.regex
 
   def match(self, input_str):
-    return re.match(self.regex, input_str, flags=re.DOTALL)
+    return re.match(self.regex, input_str, flags=re.DOTALL|re.I)
 
   def execute(self, events, *args, **kwargs):
     """
@@ -200,7 +200,7 @@ class RSVPConfirmCommand(RSVPEventNeededCommand):
   def run(self, events, *args, **kwargs):
     event_id = kwargs.pop('event_id')
     event = kwargs.pop('event')
-    decision = kwargs.pop('decision')
+    decision = kwargs.pop('decision').lower()
     sender_full_name = kwargs.pop('sender_full_name')
 
     limit = event['limit']

--- a/rsvp.py
+++ b/rsvp.py
@@ -98,7 +98,9 @@ class RSVP(object):
 
     event_id = self.event_id(message)
 
-    if content.startswith(self.key_word):
+    regex = r'^{}'.format(self.key_word)
+
+    if re.match(regex, content, flags=re.I):
       for command in self.command_list:
         matches = command.match(content)
         if matches:

--- a/tests.py
+++ b/tests.py
@@ -347,6 +347,11 @@ class RSVPTest(unittest.TestCase):
     def test_rsvp_yes_exclamation_no_plans(self):
         self.general_yes_with_no_prior_reservation('rsvp yes! i couldn\'t say no')
 
+    def test_rsvp_NO(self):
+        self.general_no_with_no_prior_reservation('rsvp hell NO!')
+
+    def test_RSVP_yes_way(self):
+        self.general_yes_with_no_prior_reservation('RSVP yes plz')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Ignore capitalization when RSVPing (i.e. RSVP YES or rsvp NO WAY) - without altering capitalization of, e.g., event description.
