### PR TITLE
Implemented move event from one stream/topic to another

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -7,7 +7,6 @@ import os
 
 import rsvp
 
-
 class bot():
     ''' bot takes a zulip username and api key, a word or phrase to respond to, a search string for giphy,
         an optional caption or list of captions, and a list of the zulip streams it should be active in.
@@ -22,7 +21,6 @@ class bot():
         self.client = zulip.Client(zulip_username, zulip_api_key, site=zulip_site)
         self.subscriptions = self.subscribe_to_streams()
         self.rsvp = rsvp.RSVP(key_word)
-
 
     @property
     def streams(self):
@@ -57,15 +55,16 @@ class bot():
     def respond(self, message):
         ''' Now we have an event dict, we should analyze it completely.
         '''
-        message = self.rsvp.process_message(message)
 
-        if message:
-            self.send_message(message)
+        replies = self.rsvp.process_message(message)
+
+        for reply in replies:
+            if reply:
+                self.send_message(reply)
             
     def send_message(self, msg):
-        ''' Sends a message to zulip stream or user
+        ''' Sends a message to zulip stream or user 
         '''
-
         msg_to = msg['display_recipient']
         if msg['type'] == 'private':
             msg_to = msg['sender_email']
@@ -102,8 +101,8 @@ zulip_api_key = os.environ['ZULIP_RSVP_KEY']
 zulip_site = os.getenv('ZULIP_RSVP_SITE', None)
 key_word = 'rsvp'
 
-sandbox_stream =  os.getenv('ZULIP_RSVP_SANDBOX_STREAM', 'test-bot')
-subscribed_streams = [sandbox_stream]
+sandbox_stream =  os.getenv('ZULIP_RSVP_SANDBOX_STREAM', '')
+subscribed_streams = []
 
 new_bot = bot(zulip_username, zulip_api_key, key_word, subscribed_streams, zulip_site=zulip_site)
 new_bot.main()

--- a/commands.py
+++ b/commands.py
@@ -181,36 +181,28 @@ class RSVPMoveCommand(RSVPEventNeededCommand):
     sender_id = kwargs.pop('sender_id')
     event = kwargs.pop('event')
     destination = kwargs.pop('destination')
+    success_msg = None
 
     # Check if the issuer of this command is the event's original creator.
-    # Only he can delete the event.
+    # Only she can modify the event.
     creator = event['creator']
 
     # check and make sure a valid Zulip stream/topic URL is passed
     if not destination: 
       body = ERROR_MISSING_MOVE_DESTINATION
-      return RSVPCommandResponse(events, RSVPMessage('stream', body))
-      
     elif creator != sender_id:
       body = ERROR_NOT_AUTHORIZED_TO_DELETE
-      return RSVPCommandResponse(events, RSVPMessage('stream', body))
-
     else:
       # split URL into components
-
       stream, topic = util.narrow_url_to_stream_topic(destination)
 
       if stream is None or topic is None:
         body = ERROR_BAD_MOVE_DESTINATION % destination
-        return RSVPCommandResponse(events, RSVPMessage('stream', body))
-
       else:
         new_event_id = stream + "/" + topic
 
         if new_event_id in events:
           body = ERROR_MOVE_ALREADY_AN_EVENT % new_event_id
-          return RSVPCommandResponse(events, RSVPMessage('stream', body))
-
         else:
           body = MSG_EVENT_MOVED % (new_event_id, destination)
 
@@ -230,7 +222,9 @@ class RSVPMoveCommand(RSVPEventNeededCommand):
             }
           )
 
-    return RSVPCommandResponse(events, RSVPMessage('stream', body), RSVPMessage('stream', MSG_INIT_SUCCESSFUL, stream, topic))
+          success_msg = RSVPMessage('stream', MSG_INIT_SUCCESSFUL, stream, topic)
+
+    return RSVPCommandResponse(events, RSVPMessage('stream', body), success_msg)
 
 class LimitReachedException(Exception):
   pass

--- a/tests.py
+++ b/tests.py
@@ -68,6 +68,8 @@ class RSVPTest(unittest.TestCase):
 
         # current stream is no longer an event
         self.assertNotIn('test-stream/Testing', self.rsvp.events)
+        self.assertEqual(2, len(output))
+
         self.assertIn("This event has been moved to [test-move/MovedTo]", output[0]['body'])
         self.assertIn("#narrow/stream/test-move/subject/MovedTo", output[0]['body'])
         self.assertIn("test-stream", output[0]['display_recipient'])
@@ -75,9 +77,20 @@ class RSVPTest(unittest.TestCase):
 
         # moved to IS now an event & was told so.
         self.assertIn('test-move/MovedTo', self.rsvp.events)
-        self.assertIn("I'm an RSVP event now", output[1]['body'])
+        self.assertIn("This thread is now an RSVPBot event! Type `rsvp help` for more options.", output[1]['body'])
         self.assertIn("test-move", output[1]['display_recipient'])
         self.assertIn("MovedTo", output[1]['subject'])
+
+    def test_move_to_already_existing_event(self):
+        self.issue_command('rsvp init')
+        output = self.issue_command('rsvp move http://testhost/#narrow/stream/test-stream/subject/Testing')
+
+        #attempted move to thread that's already an event (in this case, self)
+        self.assertEqual(1, len(output))
+        self.assertIn('test-stream/Testing', self.rsvp.events)
+        self.assertIn("Oops! `test-stream/Testing` is already an RSVPBot event", output[0]['body'])
+        self.assertIn("test-stream", output[0]['display_recipient'])
+        self.assertIn("Testing", output[0]['subject'])
 
     def test_rsvp_yes_with_no_prior_reservation(self):
         output = self.issue_command('rsvp yes')

--- a/tests.py
+++ b/tests.py
@@ -49,25 +49,41 @@ class RSVPTest(unittest.TestCase):
     def test_cannot_double_init(self):
         output = self.issue_command('rsvp init')
 
-        self.assertIn('is already an RSVPBot event', output['body'])
+        self.assertIn('is already an RSVPBot event', output[0]['body'])
 
     def test_event_cancel(self):
         output = self.issue_command('rsvp cancel')
 
         self.assertNotIn('test-stream/Testing', self.rsvp.events)
-        self.assertIn('has been canceled', output['body'])
+        self.assertIn('has been canceled', output[0]['body'])
 
     def test_cannot_double_cancel(self):
         self.issue_command('rsvp cancel')
 
         output = self.issue_command('rsvp cancel')
-        self.assertIn('is not an RSVPBot event', output['body'])
+        self.assertIn('is not an RSVPBot event', output[0]['body'])
+
+    def test_move_event(self):
+        output = self.issue_command('rsvp move http://testhost/#narrow/stream/test-move/subject/MovedTo')
+
+        # current stream is no longer an event
+        self.assertNotIn('test-stream/Testing', self.rsvp.events)
+        self.assertIn("This event has been moved to [test-move/MovedTo]", output[0]['body'])
+        self.assertIn("#narrow/stream/test-move/subject/MovedTo", output[0]['body'])
+        self.assertIn("test-stream", output[0]['display_recipient'])
+        self.assertIn("Testing", output[0]['subject'])
+
+        # moved to IS now an event & was told so.
+        self.assertIn('test-move/MovedTo', self.rsvp.events)
+        self.assertIn("I'm an RSVP event now", output[1]['body'])
+        self.assertIn("test-move", output[1]['display_recipient'])
+        self.assertIn("MovedTo", output[1]['subject'])
 
     def test_rsvp_yes_with_no_prior_reservation(self):
         output = self.issue_command('rsvp yes')
 
         self.assertEqual(None, self.event['limit'])
-        self.assertIn('is attending!', output['body'])
+        self.assertIn('is attending!', output[0]['body'])
         self.assertIn('Tester', self.event['yes'])
         self.assertNotIn('Tester', self.event['no'])
         self.assertNotIn('Tester', self.event['maybe'])
@@ -76,7 +92,7 @@ class RSVPTest(unittest.TestCase):
         output = self.issue_command('rsvp maybe')
 
         self.assertEqual(None, self.event['limit'])
-        self.assertIn("might be attending. It\'s complicated.", output['body'])
+        self.assertIn("might be attending. It\'s complicated.", output[0]['body'])
         self.assertIn('Tester', self.event['maybe'])
         self.assertNotIn('Tester', self.event['no'])
         self.assertNotIn('Tester', self.event['yes'])
@@ -84,7 +100,7 @@ class RSVPTest(unittest.TestCase):
     def test_rsvp_no_with_no_prior_reservation(self):
         output = self.issue_command('rsvp no')
 
-        self.assertIn('is **not** attending!', output['body'])
+        self.assertIn('is **not** attending!', output[0]['body'])
         self.assertNotIn('Tester', self.event['yes'])
         self.assertNotIn('Tester', self.event['maybe'])
         self.assertIn('Tester', self.event['no'])
@@ -117,7 +133,7 @@ class RSVPTest(unittest.TestCase):
         output = self.issue_command('rsvp maybe')
         count_dict = Counter(self.event['maybe'])
         self.assertEqual(1, count_dict['Tester'])
-        self.assertIn("might be attending. It\'s complicated.", output['body'])
+        self.assertIn("might be attending. It\'s complicated.", output[0]['body'])
 
         # NOT in the yes or no lists
         count_dict = Counter(self.event['yes'])
@@ -128,7 +144,7 @@ class RSVPTest(unittest.TestCase):
         output = self.issue_command('rsvp no')
         count_dict = Counter(self.event['no'])
         self.assertEqual(1, count_dict['Tester'])
-        self.assertIn('is **not** attending!', output['body'])
+        self.assertIn('is **not** attending!', output[0]['body'])
 
         # NOT in the yes or maybe lists
         count_dict = Counter(self.event['yes'])
@@ -139,7 +155,7 @@ class RSVPTest(unittest.TestCase):
         output = self.issue_command('rsvp yes')
         count_dict = Counter(self.event['yes'])
         self.assertEqual(1, count_dict['Tester'])
-        self.assertIn('is attending!', output['body'])
+        self.assertIn('is attending!', output[0]['body'])
 
         # NOT in the no or maybe lists
         count_dict = Counter(self.event['no'])
@@ -150,7 +166,7 @@ class RSVPTest(unittest.TestCase):
     def test_set_limit(self):
         output = self.issue_command('rsvp set limit 1')
 
-        self.assertIn('has been set to **1**', output['body'])
+        self.assertIn('has been set to **1**', output[0]['body'])
         self.assertEqual(1, self.event['limit'])
 
     def test_cannot_rsvp_on_a_full_event(self):
@@ -158,14 +174,14 @@ class RSVPTest(unittest.TestCase):
         self.issue_command('rsvp yes')
         output = self.issue_custom_command('rsvp yes', sender_full_name='Tester 2')
 
-        self.assertIn('The **limit** for this event has been reached!', output['body'])
+        self.assertIn('The **limit** for this event has been reached!', output[0]['body'])
 
     def test_set_date(self):
         output = self.issue_command('rsvp set date 02/25/2100')
 
         self.assertIn(
             'The date for this event has been set to **02/25/2100**!',
-            output['body']
+            output[0]['body']
         )
 
         self.assertEqual(
@@ -178,7 +194,7 @@ class RSVPTest(unittest.TestCase):
 
         self.assertIn(
             'Oops! **02/25/1000** is not a valid date in the **future**!',
-            output['body']
+            output[0]['body']
         )
 
         self.assertNotEqual(
@@ -191,7 +207,7 @@ class RSVPTest(unittest.TestCase):
     def test_set_time(self):
         output = self.issue_command('rsvp set time 10:30')
 
-        self.assertIn('has been set to **10:30**', output['body'])
+        self.assertIn('has been set to **10:30**', output[0]['body'])
         self.assertEqual('10:30', self.event['time'])
 
     def test_set_time_fail(self):
@@ -199,7 +215,7 @@ class RSVPTest(unittest.TestCase):
 
         output = self.issue_command('rsvp set time 99:99')
 
-        self.assertIn('is not a valid time', output['body'])
+        self.assertIn('is not a valid time', output[0]['body'])
         self.assertNotEqual('99:99', self.event['time'])
 
     def test_new_event_is_today(self):
@@ -213,71 +229,71 @@ class RSVPTest(unittest.TestCase):
         self.issue_command('rsvp set time 10:30')
         output = self.issue_command('rsvp set time allday')
         self.assertEqual(self.event['time'], None)
-        self.assertIn('all day long event.', output['body'])
+        self.assertIn('all day long event.', output[0]['body'])
 
     def test_set_description(self):
         output = self.issue_command('rsvp set description This is the description of the event!')
         self.assertEqual(self.event['description'], 'This is the description of the event!')
-        self.assertIn('The description for this event has been set', output['body'])
-        self.assertIn(self.event['description'], output['body'])
+        self.assertIn('The description for this event has been set', output[0]['body'])
+        self.assertIn(self.event['description'], output[0]['body'])
 
     def test_set_place(self):
         output = self.issue_command('rsvp set place Hopper!')
         self.assertEqual(self.event['place'], 'Hopper!')
-        self.assertIn('The place for this event has been set', output['body'])
-        self.assertIn(self.event['place'], output['body'])
+        self.assertIn('The place for this event has been set', output[0]['body'])
+        self.assertIn(self.event['place'], output[0]['body'])
 
     def test_summary_shows_NA_for_place_not_set(self):
         output = self.issue_command('rsvp summary')
-        self.assertIn('**Where**|N/A', output['body'])
+        self.assertIn('**Where**|N/A', output[0]['body'])
 
     def test_summary_whos_NA_for_description_not_set(self):
         output = self.issue_command('rsvp summary')
-        self.assertIn('**What**|N/A', output['body'])
+        self.assertIn('**What**|N/A', output[0]['body'])
 
     def test_summary_shows_allday_for_allday_event(self):
         output = self.issue_command('rsvp summary')
-        self.assertIn('(All day)', output['body'])
+        self.assertIn('(All day)', output[0]['body'])
 
     def test_summary_shows_description(self):
         self.issue_command('rsvp set description test description')
         output = self.issue_command('rsvp summary')
-        self.assertIn('**What**|test description', output['body'])
+        self.assertIn('**What**|test description', output[0]['body'])
 
     def test_summary_shows_place(self):
         self.issue_command('rsvp set place Hopper!')
         output = self.issue_command('rsvp summary')
-        self.assertIn('**Where**|Hopper!', output['body'])
+        self.assertIn('**Where**|Hopper!', output[0]['body'])
 
     def test_summary_shows_date(self):
         self.issue_command('rsvp set date 02/25/2100')
         output = self.issue_command('rsvp summary')
-        self.assertIn('**When**|2100-02-25', output['body'])
+        self.assertIn('**When**|2100-02-25', output[0]['body'])
 
     def test_summary_shows_limit(self):
         self.issue_command('rsvp set limit 1')
         output = self.issue_command('rsvp summary')
-        self.assertIn('**Limit**|1/1', output['body'])
+        self.assertIn('**Limit**|1/1', output[0]['body'])
 
     def test_summary_shows_no_limit_on_limit_not_set(self):
         output = self.issue_command('rsvp summary')
-        self.assertIn('**Limit**|No Limit!', output['body'])
+        self.assertIn('**Limit**|No Limit!', output[0]['body'])
 
     def test_summary_shows_time(self):
         self.issue_command('rsvp set time 10:30')
         output = self.issue_command('rsvp summary')
-        self.assertIn('10:30', output['body'])
+        self.assertIn('10:30', output[0]['body'])
 
     def test_summary_shows_thread_name(self):
         output = self.issue_command('rsvp summary')
-        self.assertIn('Testing', output['body'])
+        self.assertIn('Testing', output[0]['body'])
 
     def test_limit_actually_works(self):
         self.issue_command('rsvp set limit 500')
         self.issue_command('rsvp yes')
         output = self.issue_custom_command('rsvp yes', sender_full_name='Sender B')
 
-        self.assertEqual('@**Sender B** is attending!', output['body'])
+        self.assertEqual('@**Sender B** is attending!', output[0]['body'])
         self.assertIn('Sender B', self.event['yes'])
         self.assertEqual(498, self.event['limit'] - len(self.event['yes']))
 
@@ -299,50 +315,52 @@ class RSVPTest(unittest.TestCase):
 
         output = self.issue_command('rsvp ping')
 
-        self.assertIn('@**A**', output['body'])
-        self.assertIn('@**B**', output['body'])
-        self.assertIn('@**C**', output['body'])
-        self.assertIn('@**D**', output['body'])
+        # yeses
+        self.assertIn('@**A**', output[0]['body'])
+        self.assertIn('@**B**', output[0]['body'])
+        self.assertIn('@**C**', output[0]['body'])
+        self.assertIn('@**D**', output[0]['body'])
 
-        self.assertNotIn('@**E**', output['body'])
-        self.assertNotIn('@**F**', output['body'])
-        self.assertNotIn('@**G**', output['body'])
-        self.assertNotIn('@**H**', output['body'])
+        # maybes
+        self.assertIn('@**W**', output[0]['body'])
+        self.assertIn('@**X**', output[0]['body'])
+        self.assertIn('@**Y**', output[0]['body'])
+        self.assertIn('@**Z**', output[0]['body'])
 
-        self.assertNotIn('@**W**', output['body'])
-        self.assertNotIn('@**X**', output['body'])
-        self.assertNotIn('@**Y**', output['body'])
-        self.assertNotIn('@**Z**', output['body'])
+        self.assertNotIn('@**E**', output[0]['body'])
+        self.assertNotIn('@**F**', output[0]['body'])
+        self.assertNotIn('@**G**', output[0]['body'])
+        self.assertNotIn('@**H**', output[0]['body'])
 
     def test_ping_message(self):
         self.issue_custom_command('rsvp yes', sender_full_name='A')
 
         output = self.issue_command('rsvp ping message!!!')
 
-        self.assertIn('@**A**', output['body'])
-        self.assertIn('message!!!', output['body'])
+        self.assertIn('@**A**', output[0]['body'])
+        self.assertIn('message!!!', output[0]['body'])
 
     def test_add_description_with_message_including_yeah(self):
         output = self.issue_command('rsvp set description This is the description of the event! yeah!')
         self.assertEqual(self.event['description'], 'This is the description of the event! yeah!')
-        self.assertIn('The description for this event has been set', output['body'])
-        self.assertIn(self.event['description'], output['body'])
+        self.assertIn('The description for this event has been set', output[0]['body'])
+        self.assertIn(self.event['description'], output[0]['body'])
 
     def test_rsvp_ping_with_yes(self):
         self.issue_custom_command('rsvp yes', sender_full_name='A')
         output = self.issue_command('rsvp ping we\'re all going to the yes concert')
         self.assertEqual(None, self.event['limit'])
-        self.assertNotIn('is attending!', output['body'])
+        self.assertNotIn('is attending!', output[0]['body'])
         self.assertNotIn('Tester', self.event['yes'])
         self.assertNotIn('Tester', self.event['no'])
-        self.assertIn('@**A**', output['body'])
-        self.assertIn('we\'re all going to the yes concert', output['body'])
+        self.assertIn('@**A**', output[0]['body'])
+        self.assertIn('we\'re all going to the yes concert', output[0]['body'])
     
     def general_yes_with_no_prior_reservation(self, msg):
         output = self.issue_command(msg)
 
         self.assertEqual(None, self.event['limit'])
-        self.assertIn('is attending!', output['body'])
+        self.assertIn('is attending!', output[0]['body'])
         self.assertIn('Tester', self.event['yes'])
         self.assertNotIn('Tester', self.event['no'])
 
@@ -366,8 +384,8 @@ class RSVPTest(unittest.TestCase):
         output = self.issue_command(msg)
 
         self.assertEqual(None, self.event['limit'])
-        self.assertNotIn('is attending!', output['body'])
-        self.assertIn('is **not** attending!', output['body'])
+        self.assertNotIn('is attending!', output[0]['body'])
+        self.assertIn('is **not** attending!', output[0]['body'])
         self.assertNotIn('Tester', self.event['yes'])
         self.assertIn('Tester', self.event['no'])
 
@@ -380,9 +398,9 @@ class RSVPTest(unittest.TestCase):
     def rsvp_word_contains_command(self, msg):
         output = self.issue_command(msg)
         self.assertEqual(None, self.event['limit'])
-        self.assertIn('is not a valid RSVPBot command!', output['body'])
-        self.assertNotIn('is attending!', output['body'])
-        self.assertNotIn('is **not** attending!', output['body'])
+        self.assertIn('is not a valid RSVPBot command!', output[0]['body'])
+        self.assertNotIn('is attending!', output[0]['body'])
+        self.assertNotIn('is **not** attending!', output[0]['body'])
         self.assertNotIn('Tester', self.event['yes'])
         self.assertNotIn('Tester', self.event['no'])
 
@@ -402,9 +420,9 @@ class RSVPTest(unittest.TestCase):
     def test_rsvp_description_containing_yes(self):
         output = self.issue_command('rsvp set description lets do this yes!')
         self.assertEqual(self.event['description'], 'lets do this yes!')
-        self.assertIn('The description for this event has been set', output['body'])
-        self.assertIn(self.event['description'], output['body'])
-        self.assertNotIn('is attending!', output['body'])
+        self.assertIn('The description for this event has been set', output[0]['body'])
+        self.assertIn(self.event['description'], output[0]['body'])
+        self.assertNotIn('is attending!', output[0]['body'])
         self.assertNotIn('Tester', self.event['yes'])
 
     def test_rsvp_yes_exclamation_no_plans(self):
@@ -418,13 +436,13 @@ class RSVPTest(unittest.TestCase):
 
     def test_rsvp_private_message(self):
         output = self.issue_custom_command('rsvp yes', message_type='private')
-        self.assertEqual('private', output['type'])
-        self.assertEqual('a@example.com', output['sender_email'])
+        self.assertEqual('private', output[0]['type'])
+        self.assertEqual('a@example.com', output[0]['sender_email'])
 
     def test_rsvp_stream_message(self):
         output = self.issue_custom_command('rsvp yes', message_type='stream')
-        self.assertEqual('stream', output['type'])
-        self.assertEqual('test-stream', output['display_recipient'])
+        self.assertEqual('stream', output[0]['type'])
+        self.assertEqual('test-stream', output[0]['display_recipient'])
 
 if __name__ == '__main__':
     unittest.main()

--- a/util.py
+++ b/util.py
@@ -1,0 +1,27 @@
+import urlparse
+import urllib
+import re
+
+base = "http://localhost:9991/"
+
+def narrow_url_to_stream_topic(url):
+  parsed_url = urlparse.urlparse(url)
+  unquoted_fragment = urllib.unquote_plus(parsed_url.fragment.replace('.', '%'))
+  split_fragment = re.split('/', unquoted_fragment)
+
+  if len(split_fragment) < 5:
+    return None, None
+
+  stream = split_fragment[2]
+  topic = split_fragment[4]
+  return stream, topic
+
+def stream_topic_to_narrow_url(stream, topic):
+  quoted_stream = urllib.quote(stream)
+  quoted_topic = urllib.quote(topic)
+  fragment = ("#narrow/stream/%s/topic/%s") % (quoted_stream, quoted_topic) 
+
+  zulipped_fragment = fragment.replace('%', '.')
+  url = base + zulipped_fragment
+
+  return url


### PR DESCRIPTION
When someone accidentally inits rsvp in an inappropriate stream or topic, it isn't always a great solution to cancel and re-init in a better location because that deletes any responses & any config for the event.

This change allows the owner of the event to 'move' the event (and its associated JSON object) to another stream/topic pair (specified by the full URL of the narrowed stream/topic). 

When this is done, a message is posted to the 'outgoing' stream/topic with a link to the new stream/topic location, and a message is posted to the 'destination' stream/topic announcing that it's now an RSVP event. The ability to post to a stream/topic other than the 'active' one required a bit of a refactor, and the ability to return multiple messages from a command means that an array of messages is returned. (On the plus side, it was a great learning exercise on Python classes for me, and now RSVPbot has a mechanism to post to another stream/thread should that be necessary)

"help" text and all appropriate tests have been done (and the pingbot failing test about rsvp maybe has also been fixed). The following two images show an event that started on one thread, was moved to another, then moved back to the original. 
![started_here](https://cloud.githubusercontent.com/assets/8367204/11673572/0e38ba78-9de8-11e5-9f6d-f214017b5d8d.png)
![moved_here_then_back](https://cloud.githubusercontent.com/assets/8367204/11673573/129ba47c-9de8-11e5-8609-3f21dbdcd479.png)
