### PR TITLE
Rename duplicate test_set_date.

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -202,7 +202,7 @@ class RSVPTest(unittest.TestCase):
             self.event['date']
         )
 
-    def test_set_date(self):
+    def test_set_past_date(self):
         output = self.issue_command('rsvp set date 02/25/1000')
 
         self.assertIn(


### PR DESCRIPTION
Duplicated method name won't run - before

55 tests, after 56 tests.
