### PR TITLE
Store emails instead of names

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -7,10 +7,10 @@ import rsvp
 
 
 class Bot():
-    ''' bot takes a zulip username and api key, a word or phrase to respond to, a search string for giphy,
+    """ bot takes a zulip username and api key, a word or phrase to respond to, a search string for giphy,
         an optional caption or list of captions, and a list of the zulip streams it should be active in.
         it then posts a caption and a randomly selected gif in response to zulip messages.
-     '''
+     """
     def __init__(self, zulip_username, zulip_api_key, key_word, subscribed_streams=[], zulip_site=None):
         self.username = zulip_username
         self.api_key = zulip_api_key
@@ -23,8 +23,7 @@ class Bot():
 
     @property
     def streams(self):
-        ''' Standardizes a list of streams in the form [{'name': stream}]
-        '''
+        """Standardizes a list of streams in the form [{'name': stream}]."""
         if not self.subscribed_streams:
             streams = [{'name': stream['name']} for stream in self.get_all_zulip_streams()]
             return streams
@@ -33,8 +32,7 @@ class Bot():
             return streams
 
     def get_all_zulip_streams(self):
-        ''' Call Zulip API to get a list of all streams
-        '''
+        """Call Zulip API to get a list of all streams."""
         response = requests.get(self.client.base_url + 'v1/streams', auth=(self.username, self.api_key))
         if response.status_code == 200:
             return response.json()['streams']
@@ -44,13 +42,11 @@ class Bot():
             raise RuntimeError(':( we failed to GET streams.\n(%s)' % response)
 
     def subscribe_to_streams(self):
-        ''' Subscribes to zulip streams
-        '''
+        """Subscribes to zulip streams."""
         self.client.add_subscriptions(self.streams)
 
     def respond(self, message):
-        ''' Now we have an event dict, we should analyze it completely.
-        '''
+        """Now we have an event dict, we should analyze it completely."""
 
         replies = self.rsvp.process_message(message)
 
@@ -59,8 +55,7 @@ class Bot():
                 self.send_message(reply)
 
     def send_message(self, msg):
-        ''' Sends a message to zulip stream or user
-        '''
+        """Sends a message to zulip stream or user."""
         msg_to = msg['display_recipient']
         if msg['type'] == 'private':
             msg_to = msg['sender_email']
@@ -73,12 +68,11 @@ class Bot():
         })
 
     def main(self):
-        ''' Blocking call that runs forever. Calls self.respond() on every event received.
-        '''
+        """Blocking call that runs forever. Calls self.respond() on every event received."""
         self.client.call_on_each_message(lambda msg: self.respond(msg))
 
 
-''' The Customization Part!
+""" The Customization Part!
 
     Create a zulip bot under "settings" on zulip.
     Zulip will give you a username and API key
@@ -89,7 +83,7 @@ class Bot():
     subscribed_streams is a list of the streams the bot should be active on. An empty
         list defaults to ALL zulip streams
 
-'''
+"""
 if __name__ == "__main__":
   zulip_username = os.environ['ZULIP_RSVP_EMAIL']
   zulip_api_key = os.environ['ZULIP_RSVP_KEY']

--- a/bot.py
+++ b/bot.py
@@ -69,7 +69,7 @@ class Bot():
 
     def main(self):
         """Blocking call that runs forever. Calls self.respond() on every event received."""
-        self.client.call_on_each_message(lambda msg: self.respond(msg))
+        self.client.call_on_each_message(self.respond)
 
 
 """ The Customization Part!

--- a/bot.py
+++ b/bot.py
@@ -6,7 +6,7 @@ import os
 import rsvp
 
 
-class bot():
+class Bot():
     ''' bot takes a zulip username and api key, a word or phrase to respond to, a search string for giphy,
         an optional caption or list of captions, and a list of the zulip streams it should be active in.
         it then posts a caption and a randomly selected gif in response to zulip messages.
@@ -90,14 +90,14 @@ class bot():
         list defaults to ALL zulip streams
 
 '''
+if __name__ == "__main__":
+  zulip_username = os.environ['ZULIP_RSVP_EMAIL']
+  zulip_api_key = os.environ['ZULIP_RSVP_KEY']
+  zulip_site = os.getenv('ZULIP_RSVP_SITE', None)
+  key_word = 'rsvp'
 
-zulip_username = os.environ['ZULIP_RSVP_EMAIL']
-zulip_api_key = os.environ['ZULIP_RSVP_KEY']
-zulip_site = os.getenv('ZULIP_RSVP_SITE', None)
-key_word = 'rsvp'
+  sandbox_stream = os.getenv('ZULIP_RSVP_SANDBOX_STREAM', '')
+  subscribed_streams = []
 
-sandbox_stream = os.getenv('ZULIP_RSVP_SANDBOX_STREAM', '')
-subscribed_streams = []
-
-new_bot = bot(zulip_username, zulip_api_key, key_word, subscribed_streams, zulip_site=zulip_site)
-new_bot.main()
+  new_bot = Bot(zulip_username, zulip_api_key, key_word, subscribed_streams, zulip_site=zulip_site)
+  new_bot.main()

--- a/bot.py
+++ b/bot.py
@@ -5,6 +5,7 @@ import os
 
 import rsvp
 
+
 class bot():
     ''' bot takes a zulip username and api key, a word or phrase to respond to, a search string for giphy,
         an optional caption or list of captions, and a list of the zulip streams it should be active in.
@@ -27,10 +28,9 @@ class bot():
         if not self.subscribed_streams:
             streams = [{'name': stream['name']} for stream in self.get_all_zulip_streams()]
             return streams
-        else: 
+        else:
             streams = [{'name': stream} for stream in self.subscribed_streams]
             return streams
-
 
     def get_all_zulip_streams(self):
         ''' Call Zulip API to get a list of all streams
@@ -43,12 +43,10 @@ class bot():
         else:
             raise RuntimeError(':( we failed to GET streams.\n(%s)' % response)
 
-
     def subscribe_to_streams(self):
         ''' Subscribes to zulip streams
         '''
         self.client.add_subscriptions(self.streams)
-
 
     def respond(self, message):
         ''' Now we have an event dict, we should analyze it completely.
@@ -59,9 +57,9 @@ class bot():
         for reply in replies:
             if reply:
                 self.send_message(reply)
-            
+
     def send_message(self, msg):
-        ''' Sends a message to zulip stream or user 
+        ''' Sends a message to zulip stream or user
         '''
         msg_to = msg['display_recipient']
         if msg['type'] == 'private':
@@ -74,7 +72,6 @@ class bot():
             "content": msg['body']
         })
 
-
     def main(self):
         ''' Blocking call that runs forever. Calls self.respond() on every event received.
         '''
@@ -82,14 +79,14 @@ class bot():
 
 
 ''' The Customization Part!
-    
+
     Create a zulip bot under "settings" on zulip.
     Zulip will give you a username and API key
-    key_word is the text in Zulip you would like the bot to respond to. This may be a 
+    key_word is the text in Zulip you would like the bot to respond to. This may be a
         single word or a phrase.
     search_string is what you want the bot to search giphy for.
     caption may be one of: [] OR 'a single string' OR ['or a list', 'of strings']
-    subscribed_streams is a list of the streams the bot should be active on. An empty 
+    subscribed_streams is a list of the streams the bot should be active on. An empty
         list defaults to ALL zulip streams
 
 '''
@@ -99,7 +96,7 @@ zulip_api_key = os.environ['ZULIP_RSVP_KEY']
 zulip_site = os.getenv('ZULIP_RSVP_SITE', None)
 key_word = 'rsvp'
 
-sandbox_stream =  os.getenv('ZULIP_RSVP_SANDBOX_STREAM', '')
+sandbox_stream = os.getenv('ZULIP_RSVP_SANDBOX_STREAM', '')
 subscribed_streams = []
 
 new_bot = bot(zulip_username, zulip_api_key, key_word, subscribed_streams, zulip_site=zulip_site)

--- a/bot.py
+++ b/bot.py
@@ -1,8 +1,6 @@
 #! /usr/local/bin/python
 import zulip
-import json
 import requests
-import random
 import os
 
 import rsvp

--- a/bot.py
+++ b/bot.py
@@ -18,8 +18,9 @@ class Bot():
         self.key_word = key_word.lower()
         self.subscribed_streams = subscribed_streams
         self.client = zulip.Client(zulip_username, zulip_api_key, site=zulip_site)
+        self.client._register('get_users', method='GET', url='users')
         self.subscriptions = self.subscribe_to_streams()
-        self.rsvp = rsvp.RSVP(key_word)
+        self.rsvp = rsvp.RSVP(key_word, self.client)
 
     @property
     def streams(self):

--- a/commands.py
+++ b/commands.py
@@ -7,14 +7,13 @@ import random
 import strings
 import util
 
-"""
 
-Class that represents a response from an RSVPCommand.
-Every call to an RSVPCommand instance's execute() method is expected to return an instance
-of this class.
-
-"""
 class RSVPMessage(object):
+  """
+  Class that represents a response from an RSVPCommand.
+  Every call to an RSVPCommand instance's execute() method is expected to return an instance
+  of this class.
+  """
   def __init__(self, msg_type, body, to=None, subject=None):
     self.type = msg_type
     self.body = body
@@ -39,10 +38,11 @@ class RSVPCommandResponse(object):
       if isinstance(arg, RSVPMessage):
         self.messages.append(arg)
 
-"""
-Base class for an RSVPCommand
-"""
+
 class RSVPCommand(object):
+  """
+  Base class for an RSVPCommand
+  """
   regex = None
 
   def __init__(self, prefix, *args, **kwargs):
@@ -59,11 +59,11 @@ class RSVPCommand(object):
     """
     return self.run(events, *args, **kwargs)
 
-"""
-Base class for a command where an event needs to exist prior to execution
-"""
-class RSVPEventNeededCommand(RSVPCommand):
 
+class RSVPEventNeededCommand(RSVPCommand):
+  """
+  Base class for a command where an event needs to exist prior to execution
+  """
   def execute(self, events, *args, **kwargs):
     event = kwargs.get('event')
     if event:
@@ -106,9 +106,9 @@ class RSVPInitCommand(RSVPCommand):
     response = RSVPCommandResponse(events, RSVPMessage('stream', body))
     return response
 
+
 class RSVPHelpCommand(RSVPCommand):
   regex = r'help$'
-
 
   def run(self, events, *args, **kwargs):
     body = "**Command**|**Description**\n"
@@ -501,6 +501,7 @@ class RSVPCreditsCommand(RSVPEventNeededCommand):
 
     return RSVPCommandResponse(events, RSVPMessage('stream', body))
 
+
 class RSVPSummaryCommand(RSVPEventNeededCommand):
   regex = r'(summary$|status$)'
 
@@ -539,4 +540,3 @@ class RSVPSummaryCommand(RSVPEventNeededCommand):
 
     body = summary_table + '\n\n' + confirmation_table
     return RSVPCommandResponse(events, RSVPMessage('stream', body))
-

--- a/commands.py
+++ b/commands.py
@@ -26,7 +26,7 @@ class RSVPMessage(object):
   def __str__(self):
     attr_string = ""
     for key in dir(self):
-      attr_string += key + ":" + str(getattr(self,key)) + ", "
+      attr_string += key + ":" + str(getattr(self, key)) + ", "
     return attr_string
 
 
@@ -189,14 +189,14 @@ class RSVPMoveCommand(RSVPEventNeededCommand):
 
           # need to make sure that there's no duplicate here!
           # also, ideally we'd make sure the stream/topic existed & create it if not.
-          # AND send an 'init' notification to that new stream/toipic. Hm. what's the 
-          # best way to do that? Allow for a parameterized init? It's always a reply, not a push. 
+          # AND send an 'init' notification to that new stream/toipic. Hm. what's the
+          # best way to do that? Allow for a parameterized init? It's always a reply, not a push.
           # Can we return MULTIPLE messages instead of just one?
 
           old_event.update({'name': topic})
 
           events.update(
-            { 
+            {
               new_event_id: old_event
             }
           )
@@ -299,7 +299,7 @@ class RSVPConfirmCommand(RSVPEventNeededCommand):
   ]
 
   def confirm(self, event, sender_full_name, decision):
-    # Temporary kludge to add a 'maybe' array to legacy events. Can be removed after 
+    # Temporary kludge to add a 'maybe' array to legacy events. Can be removed after
     # all currently logged events have passed.
     if ('maybe' not in event.keys()):
       event['maybe'] = [];
@@ -307,7 +307,7 @@ class RSVPConfirmCommand(RSVPEventNeededCommand):
     # If they're in a different response list, take them out of it.
     for response in self.responses.keys():
       # prevent duplicates if replying multiple times
-      if (response == decision): 
+      if (response == decision):
         # if they're already in that list, nothing to do
         if (sender_full_name not in event[response]):
           event[response].append(sender_full_name)
@@ -337,7 +337,7 @@ class RSVPConfirmCommand(RSVPEventNeededCommand):
     vip_prefix = ''
     vip_postfix = ''
 
-    # TODO: 
+    # TODO:
     # if (this.yes_no_ambigous()):
     #   return RSVPCommandResponse("Yes no yes_no_ambigous", events)
 

--- a/commands.py
+++ b/commands.py
@@ -9,8 +9,8 @@ import util
 
 
 class RSVPMessage(object):
-  """
-  Class that represents a response from an RSVPCommand.
+  """Class that represents a response from an RSVPCommand.
+
   Every call to an RSVPCommand instance's execute() method is expected to return an instance
   of this class.
   """
@@ -40,9 +40,7 @@ class RSVPCommandResponse(object):
 
 
 class RSVPCommand(object):
-  """
-  Base class for an RSVPCommand
-  """
+  """Base class for an RSVPCommand."""
   regex = None
 
   def __init__(self, prefix, *args, **kwargs):
@@ -54,16 +52,12 @@ class RSVPCommand(object):
     return re.match(self.regex, input_str, flags=re.DOTALL|re.I)
 
   def execute(self, events, *args, **kwargs):
-    """
-    execute() is just a convenience wrapper around __run()
-    """
+    """execute() is just a convenience wrapper around __run()."""
     return self.run(events, *args, **kwargs)
 
 
 class RSVPEventNeededCommand(RSVPCommand):
-  """
-  Base class for a command where an event needs to exist prior to execution
-  """
+  """Base class for a command where an event needs to exist prior to execution."""
   def execute(self, events, *args, **kwargs):
     event = kwargs.get('event')
     if event:
@@ -411,9 +405,6 @@ class RSVPSetTimeCommand(RSVPEventNeededCommand):
     hours, minutes = int(kwargs.pop('hours')), int(kwargs.pop('minutes'))
 
     if hours in range(0, 24) and minutes in range(0, 60):
-      """
-      We'll store the time as the number of seconds since 00:00
-      """
       events[event_id]['time'] = '%02d:%02d' % (hours, minutes)
       body = strings.MSG_TIME_SET % (hours, minutes)
     else:

--- a/commands.py
+++ b/commands.py
@@ -296,7 +296,7 @@ class RSVPConfirmCommand(RSVPEventNeededCommand):
     # Temporary kludge to add a 'maybe' array to legacy events. Can be removed after
     # all currently logged events have passed.
     if ('maybe' not in event.keys()):
-      event['maybe'] = [];
+      event['maybe'] = []
 
     # If they're in a different response list, take them out of it.
     for response in self.responses.keys():
@@ -443,21 +443,36 @@ class RSVPPingCommand(RSVPEventNeededCommand):
     self.regex = self.regex.format(key_word=prefix)
 
   def run(self, events, *args, **kwargs):
+    zulip_client = args[0]
+
     event = kwargs.pop('event')
     message = kwargs.get('message')
+
+    users_result = zulip_client.get_users()
+    all_users = None
+    if users_result['result'] == 'success':
+      all_users = users_result['members']
 
     body = "**Pinging all participants who RSVP'd!!**\n"
 
     for participant in event['yes']:
-      body += "@**%s** " % participant
+      body += "@**%s** " % convert_name_or_email_to_pingable_name(all_users, participant)
 
     for participant in event['maybe']:
-      body += "@**%s** " % participant
+      body += "@**%s** " % convert_name_or_email_to_pingable_name(all_users, participant)
 
     if message:
       body += ('\n' + message)
 
     return RSVPCommandResponse(events, RSVPMessage('stream', body))
+
+
+def convert_name_or_email_to_pingable_name(all_users, name_or_email):
+  if all_users:
+    for user in all_users:
+      if user['email'] == name_or_email:
+        return user['full_name']
+  return name_or_email
 
 
 class RSVPCreditsCommand(RSVPEventNeededCommand):
@@ -498,6 +513,7 @@ class RSVPSummaryCommand(RSVPEventNeededCommand):
 
   def run(self, events, *args, **kwargs):
     event = kwargs.pop('event')
+    zulip_client = args[0]
 
     limit_str = 'No Limit!'
 
@@ -518,13 +534,18 @@ class RSVPSummaryCommand(RSVPEventNeededCommand):
 
     confirmation_table = confirmation_table.format(len(event['yes']), len(event['no']), len(event['maybe']))
 
+    users_result = zulip_client.get_users()
+    all_users = None
+    if users_result['result'] == 'success':
+      all_users = users_result['members']
+
     row_list = map(None, event['yes'], event['no'], event['maybe'])
 
     for row in row_list:
       confirmation_table += '{}|{}|{}\n'.format(
-        '' if row[0] is None else row[0],
-        '' if row[1] is None else row[1],
-        '' if row[2] is None else row[2]
+        '' if row[0] is None else convert_name_or_email_to_pingable_name(all_users, row[0]),
+        '' if row[1] is None else convert_name_or_email_to_pingable_name(all_users, row[1]),
+        '' if row[2] is None else convert_name_or_email_to_pingable_name(all_users, row[2])
       )
     else:
       confirmation_table += '\t|\t'

--- a/commands.py
+++ b/commands.py
@@ -3,8 +3,6 @@ from __future__ import unicode_literals
 import re
 import datetime
 import random
-import urlparse
-import urllib
 
 from strings import *
 import util

--- a/commands.py
+++ b/commands.py
@@ -292,7 +292,7 @@ class RSVPConfirmCommand(RSVPEventNeededCommand):
     " Oh no!!",
   ]
 
-  def confirm(self, event, sender_full_name, decision):
+  def confirm(self, event, sender_email, decision):
     # Temporary kludge to add a 'maybe' array to legacy events. Can be removed after
     # all currently logged events have passed.
     if ('maybe' not in event.keys()):
@@ -303,28 +303,29 @@ class RSVPConfirmCommand(RSVPEventNeededCommand):
       # prevent duplicates if replying multiple times
       if (response == decision):
         # if they're already in that list, nothing to do
-        if (sender_full_name not in event[response]):
-          event[response].append(sender_full_name)
+        if (sender_email not in event[response]):
+          event[response].append(sender_email)
       # else, remove all instances of them from other response lists.
-      elif sender_full_name in event[response]:
-        event[response] = [value for value in event[response] if value != sender_full_name]
+      elif sender_email in event[response]:
+        event[response] = [value for value in event[response] if value != sender_email]
 
     return event
 
-  def attempt_confirm(self, event, sender_full_name, decision, limit):
+  def attempt_confirm(self, event, sender_email, decision, limit):
     if decision == 'yes' and limit:
       available_seats = limit - len(event['yes'])
       # In this case, we need to do some extra checking for the attendance limit.
       if (available_seats - 1 < 0):
         raise LimitReachedException()
 
-    return self.confirm(event, sender_full_name, decision)
+    return self.confirm(event, sender_email, decision)
 
   def run(self, events, *args, **kwargs):
     event_id = kwargs.pop('event_id')
     event = kwargs.pop('event')
     decision = kwargs.pop('decision').lower()
     sender_full_name = kwargs.pop('sender_full_name')
+    sender_email = kwargs.pop('sender_email')
 
     limit = event['limit']
 
@@ -336,7 +337,7 @@ class RSVPConfirmCommand(RSVPEventNeededCommand):
     #   return RSVPCommandResponse("Yes no yes_no_ambigous", events)
 
     try:
-      event = self.attempt_confirm(event, sender_full_name, decision, limit)
+      event = self.attempt_confirm(event, sender_email, decision, limit)
 
       if sender_full_name in self.vips:
         if decision == 'yes':

--- a/rsvp.py
+++ b/rsvp.py
@@ -43,30 +43,22 @@ class RSVP(object):
       self.events = {}
 
   def commit_events(self):
-    """
-    Write the whole events dictionary to the filename file.
-    """
+    """Write the whole events dictionary to the filename file."""
     with open(self.filename, 'w+') as f:
       json.dump(self.events, f)
 
   def __exit__(self, type, value, traceback):
-    """
-    Before the program terminates, commit events.
-    """
+    """Before the program terminates, commit events."""
     self.commit_events()
 
   def get_this_event(self, message):
-    """
-    Returns the event relevant to this Zulip thread
-    """
+    """Returns the event relevant to this Zulip thread."""
     event_id = self.event_id(message)
 
     return self.events.get(event_id)
 
   def process_message(self, message):
-    """
-    Processes the received message and returns a new message, to send back to the user.
-    """
+    """Processes the received message and returns a new message, to send back to the user."""
 
     # adding handling of mulitples, dammit.
     replies = self.route(message)
@@ -87,9 +79,7 @@ class RSVP(object):
     return messages
 
   def route(self, message):
-    """
-    Split multiple line message and collate the responses.
-    """
+    """Split multiple line message and collate the responses."""
 
     content = message['content']
     responses = []
@@ -99,7 +89,8 @@ class RSVP(object):
     return responses
 
   def route_internal(self, message, content):
-    """
+    """Route message to matching command.
+
     To be a valid rsvp command, the string must start with the string rsvp.
     To ensure that we can match things exactly, we must remove the extra whitespace.
     We then pattern-match it with every known command pattern.
@@ -140,8 +131,8 @@ class RSVP(object):
 
 
   def create_message_from_message(self, message, body):
-    """
-    Convenience method for creating a zulip response message from a given zulip input message.
+    """Convenience method for creating a zulip response message from a
+    given zulip input message.
     """
     if body:
       return {
@@ -154,9 +145,7 @@ class RSVP(object):
 
 
   def format_message(self, message):
-    """
-    Convenience method for creating a zulip response message from an RSVP message.
-    """
+    """Convenience method for creating a zulip response message from an RSVP message."""
     return {
       'subject': message.subject,
       'display_recipient': message.to,
@@ -165,16 +154,8 @@ class RSVP(object):
     }
 
   def event_id(self, message):
-    """
-    An event's identifier is the concatenation of the 'display_recipient'
-    (zulip slang for the stream's name)
-    and the message's subject (aka the thread's title.)
-    """
-    return u'{}/{}'.format(message['display_recipient'], message['subject'])
+    """Extract the `event_id` from a message.
 
-
-  def event_id_from_subject_url(self, message):
-    """
     An event's identifier is the concatenation of the 'display_recipient'
     (zulip slang for the stream's name)
     and the message's subject (aka the thread's title.)
@@ -182,9 +163,7 @@ class RSVP(object):
     return u'{}/{}'.format(message['display_recipient'], message['subject'])
 
   def normalize_whitespace(self, content):
-    # Strips trailing and leading whitespace, and normalizes contiguous
-    # Whitespace with a single space.
-    lines = []
-    for line in content.strip().split('\n'):
-     lines.append(re.sub(r'\s+', ' ', line))
-    return lines
+    """Strips trailing and leading whitespace, and normalizes contiguous
+    whitespace with a single space.
+    """
+    return [re.sub(r'\s+', ' ', line) for line in content.strip().split('\n')]

--- a/rsvp.py
+++ b/rsvp.py
@@ -2,7 +2,7 @@ from __future__ import with_statement
 import re
 import json
 
-import commands
+import rsvp_commands
 from strings import ERROR_INVALID_COMMAND
 
 
@@ -16,21 +16,21 @@ class RSVP(object):
     self.key_word = key_word
     self.filename = filename
     self.command_list = (
-      commands.RSVPInitCommand(key_word),
-      commands.RSVPHelpCommand(key_word),
-      commands.RSVPCancelCommand(key_word),
-      commands.RSVPMoveCommand(key_word),
-      commands.RSVPSetLimitCommand(key_word),
-      commands.RSVPSetDateCommand(key_word),
-      commands.RSVPSetTimeCommand(key_word),
-      commands.RSVPSetTimeAllDayCommand(key_word),
-      commands.RSVPSetStringAttributeCommand(key_word),
-      commands.RSVPSummaryCommand(key_word),
-      commands.RSVPPingCommand(key_word),
-      commands.RSVPCreditsCommand(key_word),
+      rsvp_commands.RSVPInitCommand(key_word),
+      rsvp_commands.RSVPHelpCommand(key_word),
+      rsvp_commands.RSVPCancelCommand(key_word),
+      rsvp_commands.RSVPMoveCommand(key_word),
+      rsvp_commands.RSVPSetLimitCommand(key_word),
+      rsvp_commands.RSVPSetDateCommand(key_word),
+      rsvp_commands.RSVPSetTimeCommand(key_word),
+      rsvp_commands.RSVPSetTimeAllDayCommand(key_word),
+      rsvp_commands.RSVPSetStringAttributeCommand(key_word),
+      rsvp_commands.RSVPSummaryCommand(key_word),
+      rsvp_commands.RSVPPingCommand(key_word),
+      rsvp_commands.RSVPCreditsCommand(key_word),
 
       # This needs to be at last for fuzzy yes|no checking
-      commands.RSVPConfirmCommand(key_word)
+      rsvp_commands.RSVPConfirmCommand(key_word)
     )
     self.zulip_client = zulip_client
 
@@ -127,8 +127,8 @@ class RSVP(object):
           # the pair
           return response.messages
 
-      return [commands.RSVPMessage('stream', ERROR_INVALID_COMMAND % (content))]
-    return [commands.RSVPMessage('private', None)]
+      return [rsvp_commands.RSVPMessage('stream', ERROR_INVALID_COMMAND % (content))]
+    return [rsvp_commands.RSVPMessage('private', None)]
 
 
   def create_message_from_message(self, message, body):

--- a/rsvp.py
+++ b/rsvp.py
@@ -8,7 +8,7 @@ from strings import ERROR_INVALID_COMMAND
 
 class RSVP(object):
 
-  def __init__(self, key_word, filename='events.json'):
+  def __init__(self, key_word, zulip_client, filename='events.json'):
     """
     When created, this instance will try to open self.filename. It will always
     keep a copy in memory of the whole events dictionary and commit it when necessary.
@@ -32,6 +32,7 @@ class RSVP(object):
       # This needs to be at last for fuzzy yes|no checking
       commands.RSVPConfirmCommand(key_word)
     )
+    self.zulip_client = zulip_client
 
     try:
       with open(self.filename, "r") as f:
@@ -115,7 +116,7 @@ class RSVP(object):
           if matches.groupdict():
             kwargs.update(matches.groupdict())
 
-          response = command.execute(self.events, **kwargs)
+          response = command.execute(self.events, self.zulip_client, **kwargs)
 
           # Allow for a single events object but multiple messaages to send
           self.events = response.events

--- a/rsvp.py
+++ b/rsvp.py
@@ -60,7 +60,7 @@ class RSVP(object):
     Returns the event relevant to this Zulip thread
     """
     event_id = self.event_id(message)
-    
+
     return self.events.get(event_id)
 
   def process_message(self, message):
@@ -80,7 +80,7 @@ class RSVP(object):
       if not reply.to:
         # this uses invisible side effects and I don't care for it.
         messages.append(self.create_message_from_message(message, reply.body))
-      else: 
+      else:
         # this is sending to a stream other than the one the incoming message
         messages.append(self.format_message(reply))
 
@@ -131,7 +131,7 @@ class RSVP(object):
           self.events = response.events
           self.commit_events()
 
-          # if it has multiple messages to send, then return that instead of 
+          # if it has multiple messages to send, then return that instead of
           # the pair
           return response.messages
 
@@ -179,7 +179,7 @@ class RSVP(object):
     (zulip slang for the stream's name)
     and the message's subject (aka the thread's title.)
     """
-    return u'{}/{}'.format(message['display_recipient'], message['subject'])    
+    return u'{}/{}'.format(message['display_recipient'], message['subject'])
 
   def normalize_whitespace(self, content):
     # Strips trailing and leading whitespace, and normalizes contiguous

--- a/rsvp.py
+++ b/rsvp.py
@@ -3,7 +3,8 @@ import re
 import json
 
 import commands
-from strings import *
+from strings import ERROR_INVALID_COMMAND
+
 
 class RSVP(object):
 

--- a/rsvp.py
+++ b/rsvp.py
@@ -108,6 +108,7 @@ class RSVP(object):
           kwargs = {
             'event': self.events.get(event_id),
             'event_id': event_id,
+            'sender_email': message['sender_email'],
             'sender_full_name': message['sender_full_name'],
             'sender_id': message['sender_id'],
             'subject': message['subject'],

--- a/rsvp.py
+++ b/rsvp.py
@@ -80,7 +80,6 @@ class RSVP(object):
 
   def route(self, message):
     """Split multiple line message and collate the responses."""
-
     content = message['content']
     responses = []
     lines = self.normalize_whitespace(content)

--- a/rsvp.py
+++ b/rsvp.py
@@ -1,8 +1,6 @@
 from __future__ import with_statement
 import re
 import json
-import time
-import datetime
 
 import commands
 from strings import *

--- a/rsvp_commands.py
+++ b/rsvp_commands.py
@@ -437,6 +437,15 @@ class RSVPSetStringAttributeCommand(RSVPEventNeededCommand):
     return RSVPCommandResponse(events, RSVPMessage('stream', body))
 
 
+def get_all_users_from_zulip_client(zulip_client=None):
+    all_users = None
+    if zulip_client:
+        users_result = zulip_client.get_users()
+        if users_result['result'] == 'success':
+            all_users = users_result['members']
+    return all_users
+
+
 class RSVPPingCommand(RSVPEventNeededCommand):
   regex = r'^({key_word} ping)$|({key_word} ping (?P<message>.+))$'
 
@@ -449,12 +458,9 @@ class RSVPPingCommand(RSVPEventNeededCommand):
     event = kwargs.pop('event')
     message = kwargs.get('message')
 
-    users_result = zulip_client.get_users()
-    all_users = None
-    if users_result['result'] == 'success':
-      all_users = users_result['members']
-
     body = "**Pinging all participants who RSVP'd!!**\n"
+
+    all_users = get_all_users_from_zulip_client(zulip_client)
 
     for participant in event['yes']:
       body += "@**%s** " % convert_name_or_email_to_pingable_name(all_users, participant)
@@ -535,10 +541,7 @@ class RSVPSummaryCommand(RSVPEventNeededCommand):
 
     confirmation_table = confirmation_table.format(len(event['yes']), len(event['no']), len(event['maybe']))
 
-    users_result = zulip_client.get_users()
-    all_users = None
-    if users_result['result'] == 'success':
-      all_users = users_result['members']
+    all_users = get_all_users_from_zulip_client(zulip_client)
 
     row_list = map(None, event['yes'], event['no'], event['maybe'])
 

--- a/util.py
+++ b/util.py
@@ -16,10 +16,11 @@ def narrow_url_to_stream_topic(url):
   topic = split_fragment[4]
   return stream, topic
 
+
 def stream_topic_to_narrow_url(stream, topic):
   quoted_stream = urllib.quote(stream)
   quoted_topic = urllib.quote(topic)
-  fragment = ("#narrow/stream/%s/topic/%s") % (quoted_stream, quoted_topic) 
+  fragment = ("#narrow/stream/%s/topic/%s") % (quoted_stream, quoted_topic)
 
   zulipped_fragment = fragment.replace('%', '.')
   url = base + zulipped_fragment

--- a/util.py
+++ b/util.py
@@ -2,7 +2,8 @@ import urlparse
 import urllib
 import re
 
-base = "http://localhost:9991/"
+BASE = "http://localhost:9991/"
+
 
 def narrow_url_to_stream_topic(url):
   parsed_url = urlparse.urlparse(url)
@@ -23,6 +24,6 @@ def stream_topic_to_narrow_url(stream, topic):
   fragment = ("#narrow/stream/%s/topic/%s") % (quoted_stream, quoted_topic)
 
   zulipped_fragment = fragment.replace('%', '.')
-  url = base + zulipped_fragment
+  url = BASE + zulipped_fragment
 
   return url


### PR DESCRIPTION
Fixes that annoying problem that happens at the beginning of every batch. Users who have RSVP'd are now stored by their email address instead of their name. When a command that needs to display a user's name is called, it makes an API request to zulip's `users` endpoint to get the list of users so it can figure out what the name needed to ping them is based on the email address that's stored. 

If there are existing events with RSVP's stored by name instead of email address, `rsvp ping` and `rsvp summary` will continue to work normally for those users. 

This was based on my other PR (#23), so a better diff to look at would be https://github.com/alexandrinaw/RSVPBot/compare/make_more_pythonic...alexandrinaw:store_emails_instead_of_names
