### PR TITLE
Store name:email mapping

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -4,6 +4,7 @@ import os
 import zulip
 
 import rsvp
+import zulip_users
 
 
 class Bot():
@@ -41,6 +42,12 @@ class Bot():
         """Subscribes to zulip streams."""
         self.client.add_subscriptions(self.streams)
 
+    def process(self, event):
+        if event['type'] == 'realm_user':
+            zulip_users.update_zulip_user_dict(event['person'], self.client)
+        elif event['type'] == 'message':
+            self.respond(event['message'])
+
     def respond(self, message):
         """Now we have an event dict, we should analyze it completely."""
 
@@ -65,7 +72,7 @@ class Bot():
 
     def main(self):
         """Blocking call that runs forever. Calls self.respond() on every event received."""
-        self.client.call_on_each_message(self.respond)
+        self.client.call_on_each_event(self.process, ['message', 'realm_user'])
 
 
 """ The Customization Part!

--- a/bot.py
+++ b/bot.py
@@ -2,7 +2,6 @@
 import os
 
 import zulip
-import requests
 
 import rsvp
 
@@ -13,9 +12,6 @@ class Bot():
         it then posts a caption and a randomly selected gif in response to zulip messages.
      """
     def __init__(self, zulip_username, zulip_api_key, key_word, subscribed_streams=None, zulip_site=None):
-        self.username = zulip_username
-        self.api_key = zulip_api_key
-        self.site = zulip_site
         self.key_word = key_word.lower()
         self.subscribed_streams = subscribed_streams or []
         self.client = zulip.Client(zulip_username, zulip_api_key, site=zulip_site)
@@ -35,13 +31,11 @@ class Bot():
 
     def get_all_zulip_streams(self):
         """Call Zulip API to get a list of all streams."""
-        response = requests.get(self.client.base_url + 'v1/streams', auth=(self.username, self.api_key))
-        if response.status_code == 200:
-            return response.json()['streams']
-        elif response.status_code == 401:
-            raise RuntimeError('check yo auth')
+        response = self.client.get_streams()
+        if response['result'] == 'success':
+            return response['streams']
         else:
-            raise RuntimeError(':( we failed to GET streams.\n(%s)' % response)
+            raise RuntimeError('check yo auth')
 
     def subscribe_to_streams(self):
         """Subscribes to zulip streams."""

--- a/bot.py
+++ b/bot.py
@@ -18,7 +18,7 @@ class Bot():
         self.client = zulip.Client(zulip_username, zulip_api_key, site=zulip_site)
         self.client._register('get_users', method='GET', url='users')
         self.subscriptions = self.subscribe_to_streams()
-        self.rsvp = rsvp.RSVP(key_word, self.client)
+        self.rsvp = rsvp.RSVP(key_word)
 
     @property
     def streams(self):

--- a/rsvp.py
+++ b/rsvp.py
@@ -8,7 +8,7 @@ from strings import ERROR_INVALID_COMMAND
 
 class RSVP(object):
 
-  def __init__(self, key_word, zulip_client, filename='events.json'):
+  def __init__(self, key_word, filename='events.json'):
     """
     When created, this instance will try to open self.filename. It will always
     keep a copy in memory of the whole events dictionary and commit it when necessary.
@@ -34,7 +34,6 @@ class RSVP(object):
       # This needs to be at last for fuzzy yes|no checking
       rsvp_commands.RSVPConfirmCommand(key_word)
     )
-    self.zulip_client = zulip_client
 
     try:
       with open(self.filename, "r") as f:
@@ -118,7 +117,7 @@ class RSVP(object):
           if matches.groupdict():
             kwargs.update(matches.groupdict())
 
-          response = command.execute(self.events, self.zulip_client, **kwargs)
+          response = command.execute(self.events, **kwargs)
 
           # Allow for a single events object but multiple messaages to send
           self.events = response.events

--- a/zulip_users.py
+++ b/zulip_users.py
@@ -18,11 +18,11 @@ class ZulipUsers(object):
     def __init__(self, filename='zulip_users.json'):
         self.filename = filename
 
-        with open(self.filename, 'r') as users_file:
-            try:
+        try:
+            with open(self.filename, 'r') as users_file:
                 self.zulip_users = json.load(users_file)
-            except ValueError:
-                self.zulip_users = {}
+        except (IOError, ValueError):
+            self.zulip_users = {}
 
     def save(self):
         """Write the whole users dictionary to the filename file."""

--- a/zulip_users.py
+++ b/zulip_users.py
@@ -14,6 +14,28 @@ def _get_zulip_client():
     return client
 
 
+class ZulipUsers(object):
+    def __init__(self, filename='zulip_users.json'):
+        self.filename = filename
+
+        with open(self.filename, 'r') as users_file:
+            try:
+                self.zulip_users = json.load(users_file)
+            except ValueError:
+                self.zulip_users = {}
+
+    def save(self):
+        """Write the whole users dictionary to the filename file."""
+        with open(self.filename, 'w+') as f:
+            json.dump(self.zulip_users, f)
+
+    def convert_email_to_pingable_name(self, email):
+        """Looks up email address and returns the user's "pingable name" if they exist
+        in the dict, otherwise, just returns the email address."""
+        user = self.zulip_users.get(email)
+        return user or email
+
+
 def update_zulip_user_dict(updated_info=None, zulip_client=None):
     """Updates the `zulip_users.json` file.
 
@@ -23,31 +45,21 @@ def update_zulip_user_dict(updated_info=None, zulip_client=None):
     If `updated_info` is provided, it should be the person dict returned by the
     Zulip API in a `realm_user` event. The required keys are `email` and `full_name`.
     """
-
-    with open('zulip_users.json', 'w+') as users_file:
-        try:
-            zulip_users = json.load(users_file)
-        except ValueError:
-            zulip_users = {}
-        if updated_info:
-            new_entry = {updated_info['email']: updated_info['full_name']}
-            zulip_users.update(new_entry)
-        else:
-            client = zulip_client or _get_zulip_client()
-            users_response = client.get_users()
-            if users_response['result'] == 'success':
-                users_from_zulip_api = users_response['members']
-                for user in users_from_zulip_api:
-                    new_entry = {user['email']: user['full_name']}
-                    zulip_users.update(new_entry)
-        json.dump(zulip_users, users_file)
+    zusers = ZulipUsers()
+    if updated_info:
+        new_entry = {updated_info['email']: updated_info['full_name']}
+        zusers.zulip_users.update(new_entry)
+    else:
+        client = zulip_client or _get_zulip_client()
+        users_response = client.get_users()
+        if users_response['result'] == 'success':
+            users_from_zulip_api = users_response['members']
+            for user in users_from_zulip_api:
+                new_entry = {user['email']: user['full_name']}
+                zusers.zulip_users.update(new_entry)
+    zusers.save()
+    return zusers
 
 
-def convert_email_to_pingable_name_(email):
-    """Looks up email address in `zulip_users.json` file  and returns the user's
-    name if they exist in the dict, otherwise, just returns the email address."""
-
-    with open('zulip_users.json', 'r') as users_file:
-        zulip_users = json.load(users_file)
-    user = zulip_users.get(email)
-    return user or email
+if __name__ == '__main__':
+    update_zulip_user_dict()

--- a/zulip_users.py
+++ b/zulip_users.py
@@ -1,0 +1,53 @@
+import json
+import os
+
+import zulip
+
+
+def _get_zulip_client():
+    username = os.environ['ZULIP_RSVP_EMAIL']
+    api_key = os.environ['ZULIP_RSVP_KEY']
+    site = os.getenv('ZULIP_RSVP_SITE', 'https://zulip.com')
+
+    client = zulip.Client(username, api_key, site=site)
+    client._register('get_users', method='GET', url='users')
+    return client
+
+
+def update_zulip_user_dict(updated_info=None, zulip_client=None):
+    """Updates the `zulip_users.json` file.
+
+    If `updated_info` is not provided, it'll make a call to Zulip's /users
+    endpoint to get all users and update them all.
+
+    If `updated_info` is provided, it should be the person dict returned by the
+    Zulip API in a `realm_user` event. The required keys are `email` and `full_name`.
+    """
+
+    with open('zulip_users.json', 'w+') as users_file:
+        try:
+            zulip_users = json.load(users_file)
+        except ValueError:
+            zulip_users = {}
+        if updated_info:
+            new_entry = {updated_info['email']: updated_info['full_name']}
+            zulip_users.update(new_entry)
+        else:
+            client = zulip_client or _get_zulip_client()
+            users_response = client.get_users()
+            if users_response['result'] == 'success':
+                users_from_zulip_api = users_response['members']
+                for user in users_from_zulip_api:
+                    new_entry = {user['email']: user['full_name']}
+                    zulip_users.update(new_entry)
+        json.dump(zulip_users, users_file)
+
+
+def convert_email_to_pingable_name_(email):
+    """Looks up email address in `zulip_users.json` file  and returns the user's
+    name if they exist in the dict, otherwise, just returns the email address."""
+
+    with open('zulip_users.json', 'r') as users_file:
+        zulip_users = json.load(users_file)
+    user = zulip_users.get(email)
+    return user or email


### PR DESCRIPTION
Fixes #25 

Stores a mapping of email addresses to "pingable" names in a file called `zulip_users.json`. During `rsvp summary` and `rsvp ping` commands, it'll open the file and get the list of pingable names from there instead of making a request to the Zulip API.

The file will look something like:

```
{
    "hamlet@zulip.com": "Princess",
    "notification-bot@zulip.com": "Notification Bot",
    "error-bot@zulip.com": "Zulip Error Bot",
}
```

so it'll be quick to look up users by email address.

The bot is now listening for both events of type `message` (which it was doing before) and `realm_user` (which is new). `realm_user` updates happen whenever anything about the users in a realm change. This includes things like name changes and new users being added. Upon getting a `realm_user` event, the `zulip_users.json` file will be updated. 

Right after this is deployed, you can run the script with `python zulip_users.py`, which will make a request to get all the users from the Zulip API and store them in the file.
