### PR TITLE
add tests for #62 and fix normalize_whitespace to fix problem.

### DIFF
--- a/rsvp.py
+++ b/rsvp.py
@@ -83,7 +83,7 @@ class RSVP(object):
     """Split multiple line message and collate the responses."""
     content = message['content']
     responses = []
-    lines = self.normalize_whitespace(content)
+    lines = normalize_whitespace(content)
     for line in lines:
       responses.extend(self.route_internal(message, line))
     return responses
@@ -163,8 +163,9 @@ class RSVP(object):
     """
     return u'{}/{}'.format(message['display_recipient'], message['subject'])
 
-  def normalize_whitespace(self, content):
-    """Strips trailing and leading whitespace, and normalizes contiguous
+
+def normalize_whitespace(content):
+    """Strips trailing and leading whitespace from each line, and normalizes contiguous
     whitespace with a single space.
     """
-    return [re.sub(r'\s+', ' ', line) for line in content.strip().split('\n')]
+    return [re.sub(r'\s+', ' ', line.strip()) for line in content.strip().split('\n')]

--- a/tests.py
+++ b/tests.py
@@ -826,7 +826,6 @@ class RSVPHelpTest(RSVPTest):
             self.assertIn("`rsvp %s" % command, output[0]['body'])
 
 
-
 class RSVPMessageTypesTest(RSVPTest):
     def test_rsvp_private_message(self):
         output = self.issue_custom_command('rsvp yes', message_type='private')
@@ -840,6 +839,36 @@ class RSVPMessageTypesTest(RSVPTest):
 
 
 class RSVPMultipleCommandsTest(RSVPTest):
+    def test_rsvp_multiple_commands_with_trailing_spaces(self):
+        commands = """
+rsvp set time 10:30 
+rsvp set date 02/25/2099 
+"""
+        output = self.issue_command(commands)
+
+        self.assertIn('has been set to **10:30**', output[0]['body'])
+        self.assertEqual('10:30', self.event['time'])
+        self.assertIn('has been set to **02/25/99**!', output[1]['body'])
+        self.assertEqual( '2099-02-25', self.event['date'])
+
+    def test_rsvp_multiple_commands_with_init(self):
+        # hack to allow rsvp init to be run in whatever the "current stream" is.
+        output = self.issue_command('rsvp move http://testhost/#narrow/stream/test-move/subject/MovedTo')
+        commands = """
+rsvp init
+rsvp set time 10:30
+rsvp set date 02/25/2099
+"""
+
+        output = self.issue_command(commands)
+        event = self.get_test_event()
+
+        self.assertIn('This thread is now an RSVPBot event! Type `rsvp help` for more options.', output[0]['body'])
+        self.assertIn('has been set to **10:30**', output[1]['body'])
+        self.assertEqual('10:30', event['time'])
+        self.assertIn('has been set to **02/25/99**!', output[2]['body'])
+        self.assertEqual( '2099-02-25', event['date'])
+
     def test_rsvp_multiple_commands(self):
         commands = """
 rsvp set time 10:30


### PR DESCRIPTION
The reason for the problem in #62 was that there was a trailing space after "rsvp init", so the command wasn't matching because it was expecting `^rsvp init$`  but was actually getting `^rsvp init $`. I changed the thing that splits up a multi-line command so it strips the leading & trailing whitespace for _each_ line, instead of just from the entire message as a whole.
