### PR TITLE
Add more rsvp command aliases

### DIFF
--- a/rsvp_commands.py
+++ b/rsvp_commands.py
@@ -269,7 +269,8 @@ class RSVPConfirmCommand(RSVPEventNeededCommand):
     "out",
     "nope",
     "na(h+?)",
-    ":thumbs_?down:"
+    ":thumbs_?down:",
+    "n"
   )
 
   regex_yes = '(?P<yes_decision>%s)' % format('|'.join(yes_answers))

--- a/rsvp_commands.py
+++ b/rsvp_commands.py
@@ -260,7 +260,9 @@ class RSVPConfirmCommand(RSVPEventNeededCommand):
     "in",
     "yep",
     "ya(s+?)",
-    ":thumbs_?up:"
+    ":thumbs_?up:",
+    "y",
+    ":+1:"
   )
   no_answers = (
     "n(o+?)",

--- a/rsvp_commands.py
+++ b/rsvp_commands.py
@@ -262,7 +262,7 @@ class RSVPConfirmCommand(RSVPEventNeededCommand):
     "ya(s+?)",
     ":thumbs_?up:",
     "y",
-    ":+1:"
+    ":\+1:"
   )
   no_answers = (
     "n(o+?)",

--- a/rsvp_commands.py
+++ b/rsvp_commands.py
@@ -270,7 +270,8 @@ class RSVPConfirmCommand(RSVPEventNeededCommand):
     "nope",
     "na(h+?)",
     ":thumbs_?down:",
-    "n"
+    "n",
+    ":-1:"
   )
 
   regex_yes = '(?P<yes_decision>%s)' % format('|'.join(yes_answers))

--- a/tests.py
+++ b/tests.py
@@ -406,6 +406,9 @@ class RSVPDecisionTest(RSVPTest):
     def test_rsvp_plus_one(self):
         self.general_yes_with_no_prior_reservation('rsvp :+1:')
 
+    def test_rsvp_minus_one(self):
+        self.general_no_with_no_prior_reservation('rsvp :-1:')
+
     def test_rsvp_y(self):
         self.general_yes_with_no_prior_reservation('rsvp y')
 

--- a/tests.py
+++ b/tests.py
@@ -403,6 +403,16 @@ class RSVPDecisionTest(RSVPTest):
     def test_rsvp_thumbs_down(self):
         self.general_no_with_no_prior_reservation('rsvp :thumbs_down:')
 
+    def test_rsvp_plus_one(self):
+        self.general_yes_with_no_prior_reservation('rsvp :+1:')
+
+    def test_rsvp_y(self):
+        self.general_yes_with_no_prior_reservation('rsvp y')
+
+    def test_rsvp_n(self):
+        self.general_no_with_no_prior_reservation('rsvp n')
+
+
     def general_no_with_no_prior_reservation(self, msg):
         output = self.issue_command(msg)
 


### PR DESCRIPTION
This builds off the tireless work of @jjst by adding new command aliases
for `rsvp yes`:
- `:+1:` is the short form of `:thumbs_up:` (because who has time to
  write `:thumbs_up:`?)
- `y` is just  short for `yes` (because who has time to write `yes`?)
- `n` is just  short for `no` (because who has time to write `no`?)

This PR also addresses #65
