### PR TITLE
Add pluggable event backend support

### DIFF
--- a/backends/__init__.py
+++ b/backends/__init__.py
@@ -1,0 +1,71 @@
+import json
+
+__all__ = ['AbstractBackend', 'FileBackend']
+
+class AbstractBackend(object):
+
+    def __init__(self, *args, **kwargs):
+        super(AbstractBackend, self).__init__(*args, **kwargs)
+
+    def get_all_events(self):
+        """
+        Must return a dictionary with the form:
+
+        {
+            "<thread_name_1>": {
+                "name": "<event_name>",
+                "description": "<description_1>",
+                "yes": ["<email_1>", "<email_2>", ...],
+                "no": ["<email_1>", "<email_2>", ...],
+                "maybe": ["<email_1>", "<email_2>", ...],
+                "creator": int(<creator_user_id>),
+                "duration": int(<duration_seconds>) or None,
+                "place": "<place_name>" or None,
+                "time": "<%H:%m>" or None, # refer to http://strftime.org/ for % meaning.
+                "date": "<%Y-%m-%d>" or None,
+                "limit": int(<max_limit_people>) or None
+                "calendar_event": {
+                    "html_link": "<cal_event_url>",
+                    "id": "<cal_event_id>",
+                } or None,
+            },
+            "<thread_name_2>": {...}
+        } or {}
+        """
+        raise NotImplementedError('You must override the get_all_events method.')
+
+
+    def commit_events(self, events):
+        """
+        Should write the events to any long-term storage by any means necessary.
+        """
+        raise NotImplementedError('You must override the commit_events method.')
+
+
+class FileBackend(AbstractBackend):
+
+    filename = None
+
+    def __init__(self, filename, *args, **kwargs):
+        self.filename = filename
+        super(FileBackend, self).__init__(*args, **kwargs)
+
+
+    def get_all_events(self):
+        events = {}
+        try:
+            with open(self.filename, "r") as f:
+                try:
+                    events = json.load(f)
+                except ValueError as v_exc:
+                    pass
+        except IOError as io_exc:
+            pass
+
+        return events
+
+
+    def commit_events(self, events):
+        """Write the whole events dictionary to the filename file."""
+        with open(self.filename, 'w+') as f:
+            json.dump(events, f)

--- a/bot.py
+++ b/bot.py
@@ -6,6 +6,8 @@ import zulip
 import rsvp
 import zulip_users
 
+from backends import FileBackend
+
 
 class Bot():
     """ bot takes a zulip username and api key, a word or phrase to respond to, a search string for giphy,
@@ -18,7 +20,14 @@ class Bot():
         self.client = zulip.Client(zulip_username, zulip_api_key, site=zulip_site)
         self.client._register('get_users', method='GET', url='users')
         self.subscriptions = self.subscribe_to_streams()
-        self.rsvp = rsvp.RSVP(key_word)
+        self.rsvp = rsvp.RSVP(key_word, self.get_backend)
+
+
+    def get_backend(self):
+        """
+        Return an instance of a backend class that this bot will use
+        """
+        return FileBackend(filename='events.json')
 
     @property
     def streams(self):

--- a/bot.py
+++ b/bot.py
@@ -20,7 +20,7 @@ class Bot():
         self.client = zulip.Client(zulip_username, zulip_api_key, site=zulip_site)
         self.client._register('get_users', method='GET', url='users')
         self.subscriptions = self.subscribe_to_streams()
-        self.rsvp = rsvp.RSVP(key_word, self.get_backend)
+        self.rsvp = rsvp.RSVP(key_word, self.get_backend())
 
 
     def get_backend(self):

--- a/bot.py
+++ b/bot.py
@@ -10,9 +10,9 @@ from backends import FileBackend
 
 
 class Bot():
-    """ bot takes a zulip username and api key, a word or phrase to respond to, a search string for giphy,
-        an optional caption or list of captions, and a list of the zulip streams it should be active in.
-        it then posts a caption and a randomly selected gif in response to zulip messages.
+    """ bot takes a zulip username and api key, a word or phrase to respond to,
+        an optional list of the zulip streams it should be active in,
+        and the zulip site to connect to.
      """
     def __init__(self, zulip_username, zulip_api_key, key_word, subscribed_streams=None, zulip_site=None):
         self.key_word = key_word.lower()
@@ -90,8 +90,6 @@ class Bot():
     Zulip will give you a username and API key
     key_word is the text in Zulip you would like the bot to respond to. This may be a
         single word or a phrase.
-    search_string is what you want the bot to search giphy for.
-    caption may be one of: [] OR 'a single string' OR ['or a list', 'of strings']
     subscribed_streams is a list of the streams the bot should be active on. An empty
         list defaults to ALL zulip streams
 

--- a/rsvp.py
+++ b/rsvp.py
@@ -8,13 +8,14 @@ from strings import ERROR_INVALID_COMMAND
 
 class RSVP(object):
 
-  def __init__(self, key_word, filename='events.json'):
+  def __init__(self, key_word, backend):
     """
-    When created, this instance will try to open self.filename. It will always
-    keep a copy in memory of the whole events dictionary and commit it when necessary.
+    keep a copy in memory of the whole events dictionary and commit it when necessary
+    to the supplied backend.
     """
+
+    self.backend = backend
     self.key_word = key_word
-    self.filename = filename
     self.command_list = (
       rsvp_commands.RSVPInitCommand(key_word),
       rsvp_commands.RSVPHelpCommand(key_word),
@@ -35,19 +36,11 @@ class RSVP(object):
       rsvp_commands.RSVPConfirmCommand(key_word)
     )
 
-    try:
-      with open(self.filename, "r") as f:
-        try:
-          self.events = json.load(f)
-        except ValueError:
-          self.events = {}
-    except IOError:
-      self.events = {}
+    self.events = self.backend.get_all_events()
 
   def commit_events(self):
-    """Write the whole events dictionary to the filename file."""
-    with open(self.filename, 'w+') as f:
-      json.dump(self.events, f)
+    """Write the whole events dictionary to the backend."""
+    self.backend.commit_events(self.events)
 
   def __exit__(self, type, value, traceback):
     """Before the program terminates, commit events."""

--- a/tests.py
+++ b/tests.py
@@ -9,6 +9,7 @@ import calendar_events
 import rsvp
 import rsvp_commands
 from zulip_users import ZulipUsers
+from backends import FileBackend
 
 
 class CalendarEventTest(unittest.TestCase):
@@ -145,7 +146,7 @@ class CalendarEventTest(unittest.TestCase):
 class RSVPTest(unittest.TestCase):
 
     def setUp(self):
-        self.rsvp = rsvp.RSVP('rsvp', filename='test.json')
+        self.rsvp = rsvp.RSVP('rsvp', FileBackend(filename='test.json'))
         self.issue_command('rsvp init')
         self.event = self.get_test_event()
 


### PR DESCRIPTION
Hey @davidbalbert, check this out.

This is some initial groundwork for pluggable event backends in RSVPBot. Your part here would be to subclass `AbstractBackend` and implement the `get_all_events` and `commit_events` methods, and then do whatever setup your backend instance needs in the `get_backend` method of the `Bot` class.

Tests are passing in this PR.

Let me know if you have any questions, suggestions or ideas.